### PR TITLE
implement 'load more' on contributor page. On contributor page, such …

### DIFF
--- a/craft/templates/about/_contributor.html
+++ b/craft/templates/about/_contributor.html
@@ -54,35 +54,93 @@
 {% set js %}
   $(function() {
     var authorId = '{{ craft.request.segment(3) }}';
+    
+    /**
+     * offset[section] denotes number of already fetched entries for each section
+     * where section is blog, news, notices, media or letters
+     */ 
+    var offset = {
+      'blog': 0,
+      'news': 0,
+      'notices': 0,
+      'media': 0,
+      'letters': 0
+    };
+    
+    /**
+     * limit denotes how many entries to retrieve
+     */ 
+    const limit = 20;
+    
+    /**
+     * list[section] denotes the dom element to which entries are appended to. 
+     * where section is blog, news, notices, media or letters
+     */
+    var $list = {
+      'blog': null,
+      'news': null,
+      'notices': null,
+      'media': null,
+      'letters': null
+    }
 
     $('h3.my-content a').click(function(e) {
       var $link   = $(this);
-      var $parent = $link.parent();
-      var $list   = $parent.next('ul.posts');
+      var $parent = $link.parent();      
       var section = $parent[0].dataset.section;
-
-      console.log('authorId', authorId, 'section', section);
+      $list[section]  = $parent.next('ul.posts');     
 
       if ($parent.hasClass('active')) {
-        $list.hide();
+        $list[section].hide();
       } else {
-        if ($list.children().length == 0) {
-          $link.append('<img src="/img/spinner.gif" style="padding-left: 8px">');
+        if ($list[section].children().length == 0) {
+          $link.append('<img id="spinner" src="/img/spinner.gif" style="padding-left: 8px">');
 
-          $list.load(
+          $list[section].load(
             '/about/contributor_entries',
-            {authorId: authorId, section: section},
+            {authorId: authorId, section: section, offset: offset[section], limit: limit},
             function() {
               $link.find('img').remove();
+              $list[section].append('<input type="button" id="btn-load-more" value="Load More..." style="margin-bottom: .5em;" data-section="'+section+'"/>');
+              offset[section] = offset[section] + limit;
             }
           );
         }
 
-        $list.show();
+        $list[section].show();
       }
 
       e.preventDefault();
     });
+
+    /**
+     * Click handler for 'Load More...' button. Fetches the posts depending on the 'limit' 
+     * and appends them to the specified section (blog, news, notices, media, letters).
+     *
+     * #btn-load-more is not created in DOM. Therefore, we attach the listener using .on().
+     */
+    $(document).on('click', '#btn-load-more', function(e) {
+      $loadMoreBtn = $(this);
+      var section = $loadMoreBtn.data('section');
+      
+      $list[section].append('<img id="spinner" src="/img/spinner.gif" style="padding-left: 8px">');
+
+      $list[section].append($('<div>').load(
+        '/about/contributor_entries',
+        {authorId: authorId, section: section, offset: offset[section], limit: limit},
+        function(result) {
+          $list[section].find('#spinner').remove();          
+          $loadMoreBtn.remove();
+          $loadMoreBtn.find('img').remove();
+          if(result){
+            $list[section].append($loadMoreBtn);
+            offset[section] = offset[section] + limit;
+          }          
+        }
+      ));
+
+      e.preventDefault();
+    });    
   });
 {% endset %}
 {% includeJs js %}

--- a/craft/templates/about/_contributor.html
+++ b/craft/templates/about/_contributor.html
@@ -101,7 +101,7 @@
             {authorId: authorId, section: section, offset: offset[section], limit: limit},
             function() {
               $link.find('img').remove();
-              $list[section].append('<input type="button" id="btn-load-more" value="Load More..." style="margin-bottom: .5em;" data-section="'+section+'"/>');
+              $list[section].append('<div style="text-align: center;"><input type="button" id="btn-load-more" value="Load More..." style="margin-bottom: .5em;" data-section="'+section+'"/></div>');
               offset[section] = offset[section] + limit;
             }
           );
@@ -129,11 +129,10 @@
         '/about/contributor_entries',
         {authorId: authorId, section: section, offset: offset[section], limit: limit},
         function(result) {
-          $list[section].find('#spinner').remove();          
-          $loadMoreBtn.remove();
-          $loadMoreBtn.find('img').remove();
+          $list[section].find('#spinner').remove();
+          $loadMoreBtn.parent().remove();          
           if(result){
-            $list[section].append($loadMoreBtn);
+            $list[section].append($loadMoreBtn.parent());
             offset[section] = offset[section] + limit;
           }          
         }

--- a/craft/templates/about/contributor_entries.html
+++ b/craft/templates/about/contributor_entries.html
@@ -4,8 +4,10 @@
 
 {% set authorId = craft.request.param('authorId') %}
 {% set section  = craft.request.param('section') %}
+{% set offset  = craft.request.param('offset') %}
+{% set limit  = craft.request.param('limit') %}
 
-{% set entries = craft.entries.authorId(authorId).section(section).limit(null) %}
+{% set entries = craft.entries.authorId(authorId).section(section).offset(offset).limit(limit) %}
 
 {% import "_entry/macros" as m %}
 


### PR DESCRIPTION
Implement 'load more' on contributor page.

On [contributor page](https://marinpost.org/about/contributors/669/marin-post), expanding any section (blog, news, notices, media, letters) currently fetches *all* entries leading to slow load tim
es. With this change, only fixed entries are fetched (20) and to fetch more, a 'Load More...' button that displays at bottom of the expanded section can be clicked. Clicking it fetches 20 more entries and those entries are appended to the section.

This change also removes a console.log() because no client-side logging should be done in production.

Changes tested on OSX on Chrome, Firefox & Safari.