### PR TITLE
[Contributor Profile] #2 Hide 'Load More' when all entries fetched + hide sections when no entries exist

### DIFF
--- a/craft/templates/about/_contributor.html
+++ b/craft/templates/about/_contributor.html
@@ -100,9 +100,11 @@
             '/about/contributor_entries',
             {authorId: authorId, section: section, offset: offset[section], limit: limit},
             function(result) {
-             $list[section].html(result);
+              $list[section].html(result);
               $link.find('img').remove();
-              $list[section].append('<div style="text-align: center;"><input type="button" id="btn-load-more" value="Load More..." style="margin-bottom: .5em;" data-section="'+section+'"/></div>');
+              if($(result).filter('.listing').length == limit){
+                $list[section].append('<div style="text-align: center;"><input type="button" id="btn-load-more" value="Load More..." style="margin-bottom: .5em;" data-section="'+section+'"/></div>');
+              }
               offset[section] = offset[section] + limit;
             }
           );
@@ -112,6 +114,24 @@
       }
 
       e.preventDefault();
+    });
+
+    /**
+     * Hide sections if they do not contain any entries.
+     */
+    $.each( $('h3.my-content'), function( index, sectionHeadingElem ){
+      var section = sectionHeadingElem.dataset.section;
+      if(section){
+        $.get(
+          '/about/contributor_entries',
+          {authorId: authorId, section: section, offset: offset[section], limit: limit},
+          function(result) {
+            if(!result){                  
+              $(sectionHeadingElem).hide();
+            }
+          }
+        );
+      }
     });
 
     /**
@@ -134,7 +154,8 @@
           $list[section].find('#spinner').remove();
           $loadMoreBtn.parent().remove();
           if(result){
-            $list[section].append($loadMoreBtn.parent());
+            if($(result).filter('.listing').length == limit)
+              $list[section].append($loadMoreBtn.parent());
             offset[section] = offset[section] + limit;
           }
         }

--- a/craft/templates/about/_contributor.html
+++ b/craft/templates/about/_contributor.html
@@ -35,134 +35,18 @@
         {{ p.documents(user.userDocuments) }}
       </div>
 
-      <h3 class="my-content" data-section="blog"><a href="#">My Blog Posts</a></h3>
+      <h3 class="my-content" data-section="blog" style="display:none"><a href="#">My Blog Posts</a></h3>
+      <ul class="posts" style="display:none" style="display:none"></ul>
+      <h3 class="my-content" data-section="news" style="display:none"><a href="#">My News Links</a></h3>
       <ul class="posts" style="display:none"></ul>
-      <h3 class="my-content" data-section="news"><a href="#">My News Links</a></h3>
+      <h3 class="my-content" data-section="notices" style="display:none"><a href="#">My Notices</a></h3>
       <ul class="posts" style="display:none"></ul>
-      <h3 class="my-content" data-section="notices"><a href="#">My Notices</a></h3>
+      <h3 class="my-content" data-section="media" style="display:none"><a href="#">My Media Links</a></h3>
       <ul class="posts" style="display:none"></ul>
-      <h3 class="my-content" data-section="media"><a href="#">My Media Links</a></h3>
-      <ul class="posts" style="display:none"></ul>
-      <h3 class="my-content" data-section="letters"><a href="#">My Letters</a></h3>
+      <h3 class="my-content" data-section="letters" style="display:none"><a href="#">My Letters</a></h3>
       <ul class="posts" style="display:none"></ul>
 
       {% include "_common/disqus_count.html" %}
     {% endblock %}
   {% endembed %}
 {% endblock %}
-
-{% set js %}
-  $(function() {
-    var authorId = '{{ craft.request.segment(3) }}';
-    
-    /**
-     * offset[section] denotes number of already fetched entries for each section
-     * where section is blog, news, notices, media or letters
-     */ 
-    var offset = {
-      'blog': 0,
-      'news': 0,
-      'notices': 0,
-      'media': 0,
-      'letters': 0
-    };
-    
-    /**
-     * limit denotes how many entries to retrieve
-     */ 
-    const limit = 20;
-    
-    /**
-     * list[section] denotes the dom element to which entries are appended to. 
-     * where section is blog, news, notices, media or letters
-     */
-    var $list = {
-      'blog': null,
-      'news': null,
-      'notices': null,
-      'media': null,
-      'letters': null
-    }
-
-    $('h3.my-content a').click(function(e) {
-      var $link   = $(this);
-      var $parent = $link.parent();      
-      var section = $parent[0].dataset.section;
-      $list[section]  = $parent.next('ul.posts');     
-
-      if ($parent.hasClass('active')) {
-        $list[section].hide();
-      } else {
-        if ($list[section].children().length == 0) {
-          $link.append('<img id="spinner" src="/img/spinner.gif" style="padding-left: 8px">');
-
-          $.get(
-            '/about/contributor_entries',
-            {authorId: authorId, section: section, offset: offset[section], limit: limit},
-            function(result) {
-              $list[section].html(result);
-              $link.find('img').remove();
-              if($(result).filter('.listing').length == limit){
-                $list[section].append('<div style="text-align: center;"><input type="button" id="btn-load-more" value="Load More..." style="margin-bottom: .5em;" data-section="'+section+'"/></div>');
-              }
-              offset[section] = offset[section] + limit;
-            }
-          );
-        }
-
-        $list[section].show();
-      }
-
-      e.preventDefault();
-    });
-
-    /**
-     * Hide sections if they do not contain any entries.
-     */
-    $.each( $('h3.my-content'), function( index, sectionHeadingElem ){
-      var section = sectionHeadingElem.dataset.section;
-      if(section){
-        $.get(
-          '/about/contributor_entries',
-          {authorId: authorId, section: section, offset: offset[section], limit: limit},
-          function(result) {
-            if(!result){                  
-              $(sectionHeadingElem).hide();
-            }
-          }
-        );
-      }
-    });
-
-    /**
-     * Click handler for 'Load More...' button. Fetches the posts depending on the 'limit' 
-     * and appends them to the specified section (blog, news, notices, media, letters).
-     *
-     * #btn-load-more is not created in DOM. Therefore, we attach the listener using .on().
-     */
-    $(document).on('click', '#btn-load-more', function(e) {
-      $loadMoreBtn = $(this);
-      var section = $loadMoreBtn.data('section');
-      
-      $list[section].append('<img id="spinner" src="/img/spinner.gif" style="padding-left: 8px">');
-
-      $.get(
-        '/about/contributor_entries',
-        {authorId: authorId, section: section, offset: offset[section], limit: limit},
-        function(result) {
-          $list[section].append($('<div>').html(result));
-          $list[section].find('#spinner').remove();
-          $loadMoreBtn.parent().remove();
-          if(result){
-            if($(result).filter('.listing').length == limit)
-              $list[section].append($loadMoreBtn.parent());
-            offset[section] = offset[section] + limit;
-          }
-        }
-      );
-
-      e.preventDefault();
-    });
-  });
-{% endset %}
-{% includeJs js %}

--- a/craft/templates/about/contributor_entries.html
+++ b/craft/templates/about/contributor_entries.html
@@ -6,13 +6,17 @@
 {% set section  = craft.request.param('section') %}
 {% set offset  = craft.request.param('offset') %}
 {% set limit  = craft.request.param('limit') %}
-
+{% set totEntries = craft.entries.authorId(authorId).section(section) %}
 {% set entries = craft.entries.authorId(authorId).section(section).offset(offset).limit(limit) %}
 
+{% set entriesHTML = "" %}
 {% import "_entry/macros" as m %}
-
 {% for entry in entries %}
-  {{ m.post(entry) }}
+  {% set entriesHTML = entriesHTML ~ m.post(entry) %}
 {% endfor %}
-
+{
+  "total_count" : {{ totEntries | length }},
+  "count" : {{ entries | length }},
+  "html" : "{{ entriesHTML | json_encode() }}"
+}
 {% endspaceless %}

--- a/public/js/about.js
+++ b/public/js/about.js
@@ -7,6 +7,131 @@ $(function() {
 
   if (m = document.location.pathname.match(/(^\/about\/contributors\/\d+\/\S+)/)) {
     contributorRadioButtons.find('input[value$="'+m[1]+'"]').attr('checked', 'checked');
+
+    /**
+     * offset[section] denotes number of already fetched entries for each section
+     * where section is blog, news, notices, media or letters
+     */
+    var offset = {
+      'blog': 0,
+      'news': 0,
+      'notices': 0,
+      'media': 0,
+      'letters': 0
+    };
+
+    /**
+     * limit denotes how many entries to retrieve
+     */
+    const limit = 10;
+
+    /**
+     * list[section] denotes the dom element to which entries are appended to. 
+     * where section is blog, news, notices, media or letters
+     */
+    var $list = {
+      'blog': null,
+      'news': null,
+      'notices': null,
+      'media': null,
+      'letters': null
+    }
+
+    /**
+     * Contributors Page
+     * 
+     * Click handler for section arrows.
+     */
+    $('h3.my-content a').click(function (e) {
+      var $link = $(this);
+      var $parent = $link.parent();
+      var section = $parent[0].dataset.section;
+      $list[section] = $parent.next('ul.posts');
+      var pathArray = window.location.pathname.split('\/');
+      var authorId = pathArray[3];
+
+      if ($parent.hasClass('active')) {
+        $list[section].hide();
+      } else {
+        if ($list[section].children().length == 0) {
+          $link.append('<img id="spinner" src="/img/spinner.gif" style="padding-left: 8px">');
+
+          $.get(
+            '/about/contributor_entries',
+            { authorId: authorId, section: section, offset: offset[section], limit: limit },
+            function (result) {
+              $list[section].html(result);
+              $link.find('img').remove();
+              if ($(result).filter('.listing').length == limit) {
+                $list[section].append('<div style="text-align: center;"><input type="button" id="btn-load-more" value="Load More..." style="margin-bottom: .5em;" data-section="' + section + '"/></div>');
+              }
+              offset[section] = offset[section] + limit;
+            }
+          );
+        }
+
+        $list[section].show();
+      }
+
+      e.preventDefault();
+    });
+
+    /**
+     * Contributors Page
+     * 
+     * Hide sections if they do not contain any entries.
+     */
+    $.each($('h3.my-content'), function (index, sectionHeadingElem) {
+      var pathArray = window.location.pathname.split('\/');
+      var authorId = pathArray[3];
+      var section = sectionHeadingElem.dataset.section;
+      if (section) {
+        $.get(
+          '/about/contributor_entries',
+          { authorId: authorId, section: section, offset: offset[section], limit: limit },
+          function (result) {
+            if (result) {
+              $(sectionHeadingElem).show();
+            } else {
+              $(sectionHeadingElem).hide();
+            }
+          }
+        );
+      }
+    });
+
+    /**
+     * Contributors page
+     * 
+     * Click handler for 'Load More...' button. Fetches the posts depending on the 'limit' 
+     * and appends them to the specified section (blog, news, notices, media, letters).
+     *
+     * #btn-load-more is not created in DOM. Therefore, we attach the listener using .on().
+     */
+    $(document).on('click', '#btn-load-more', function (e) {
+      var pathArray = window.location.pathname.split('\/');
+      var authorId = pathArray[3];
+      $loadMoreBtn = $(this);
+      var section = $loadMoreBtn.data('section');
+      $list[section].append('<img id="spinner" src="/img/spinner.gif" style="padding-left: 8px">');
+
+      $.get(
+        '/about/contributor_entries',
+        { authorId: authorId, section: section, offset: offset[section], limit: limit },
+        function (result) {
+          $list[section].append($('<div>').html(result));
+          $list[section].find('#spinner').remove();
+          $loadMoreBtn.parent().remove();
+          if (result) {
+            if ($(result).filter('.listing').length == limit)
+              $list[section].append($loadMoreBtn.parent());
+            offset[section] = offset[section] + limit;
+          }
+        }
+      );
+
+      e.preventDefault();
+    });
   }
 
   contributorRadioButtons.find('input').click(function(e) {

--- a/public/js/about.js
+++ b/public/js/about.js
@@ -6,7 +6,7 @@ $(function() {
   }
 
   if (m = document.location.pathname.match(/(^\/about\/contributors\/\d+\/\S+)/)) {
-    contributorRadioButtons.find('input[value$="'+m[1]+'"]').attr('checked', 'checked');
+    contributorRadioButtons.find('input[value$="' + m[1] + '"]').attr('checked', 'checked');
 
     /**
      * offset[section] denotes number of already fetched entries for each section
@@ -61,9 +61,12 @@ $(function() {
             '/about/contributor_entries',
             { authorId: authorId, section: section, offset: offset[section], limit: limit },
             function (result) {
-              $list[section].html(result);
+              var html = JSON.parse(result).html.substring(6, JSON.parse(result).html.length - 6 );
+              var totalCount = JSON.parse(result).total_count;
+              var count = JSON.parse(result).count;
+              $list[section].html(html);
               $link.find('img').remove();
-              if ($(result).filter('.listing').length == limit) {
+              if (totalCount > offset[section]+ count) {
                 $list[section].append('<div style="text-align: center;"><input type="button" id="btn-load-more" value="Load More..." style="margin-bottom: .5em;" data-section="' + section + '"/></div>');
               }
               offset[section] = offset[section] + limit;
@@ -82,18 +85,18 @@ $(function() {
      * 
      * Hide sections if they do not contain any entries.
      */
-    $.each($('h3.my-content'), function (index, sectionHeadingElem) {      
+    $.each($('h3.my-content'), function (index, sectionHeadingElem) {
       var section = sectionHeadingElem.dataset.section;
       if (section) {
         $.get(
           '/about/contributor_entries',
           { authorId: authorId, section: section, offset: offset[section], limit: limit },
           function (result) {
-            if (result) {
-              $(sectionHeadingElem).show();
-            } else {
+            var totalCount = JSON.parse(result).total_count;
+            if(totalCount == 0)
               $(sectionHeadingElem).hide();
-            }
+            else 
+              $(sectionHeadingElem).show();            
           }
         );
       }
@@ -107,7 +110,7 @@ $(function() {
      *
      * #btn-load-more is not created in DOM. Therefore, we attach the listener using .on().
      */
-    $(document).on('click', '#btn-load-more', function (e) {      
+    $(document).on('click', '#btn-load-more', function (e) {
       $loadMoreBtn = $(this);
       var section = $loadMoreBtn.data('section');
       $list[section].append('<img id="spinner" src="/img/spinner.gif" style="padding-left: 8px">');
@@ -116,14 +119,18 @@ $(function() {
         '/about/contributor_entries',
         { authorId: authorId, section: section, offset: offset[section], limit: limit },
         function (result) {
-          $list[section].append($('<div>').html(result));
+          var html = JSON.parse(result).html.substring(6, JSON.parse(result).html.length - 6 );
+          var totalCount = JSON.parse(result).total_count;
+          var count = JSON.parse(result).count;
+
+          $list[section].append($('<div>').html(html));
           $list[section].find('#spinner').remove();
           $loadMoreBtn.parent().remove();
-          if (result) {
-            if ($(result).filter('.listing').length == limit)
-              $list[section].append($loadMoreBtn.parent());
-            offset[section] = offset[section] + limit;
+
+          if (totalCount > offset[section] + count) {
+            $list[section].append($loadMoreBtn.parent());
           }
+          offset[section] = offset[section] + limit;          
         }
       );
 

--- a/public/js/about.js
+++ b/public/js/about.js
@@ -37,6 +37,9 @@ $(function() {
       'letters': null
     }
 
+    var pathArray = window.location.pathname.split('\/');
+    var authorId = pathArray[3];
+
     /**
      * Contributors Page
      * 
@@ -47,8 +50,6 @@ $(function() {
       var $parent = $link.parent();
       var section = $parent[0].dataset.section;
       $list[section] = $parent.next('ul.posts');
-      var pathArray = window.location.pathname.split('\/');
-      var authorId = pathArray[3];
 
       if ($parent.hasClass('active')) {
         $list[section].hide();
@@ -81,9 +82,7 @@ $(function() {
      * 
      * Hide sections if they do not contain any entries.
      */
-    $.each($('h3.my-content'), function (index, sectionHeadingElem) {
-      var pathArray = window.location.pathname.split('\/');
-      var authorId = pathArray[3];
+    $.each($('h3.my-content'), function (index, sectionHeadingElem) {      
       var section = sectionHeadingElem.dataset.section;
       if (section) {
         $.get(
@@ -108,9 +107,7 @@ $(function() {
      *
      * #btn-load-more is not created in DOM. Therefore, we attach the listener using .on().
      */
-    $(document).on('click', '#btn-load-more', function (e) {
-      var pathArray = window.location.pathname.split('\/');
-      var authorId = pathArray[3];
+    $(document).on('click', '#btn-load-more', function (e) {      
       $loadMoreBtn = $(this);
       var section = $loadMoreBtn.data('section');
       $list[section].append('<img id="spinner" src="/img/spinner.gif" style="padding-left: 8px">');


### PR DESCRIPTION
Issue:
2. CONTRIBUTOR PROFILE PAGE

1) If a user has less than 20 entries under any of the categories at the bottom of their Profile (My Blogs, My Notices, My Media Links, etc.), then the “Load More” button should not show up at the bottom of the list of posts that is generated.
Piyush Note: Current implementation is unaware of the ‘total’ number of entries. It simply retrieves the next 20 entries until the returned entries are 0 which is when 'Load More’ button is hidden. We can achieve what you want by hiding Load More if entries retrieved < 20 (current limit) signifying that no more entries should exist.

2) If a user has no posts in any of the five categories, then the "arrow/title widget" for that category should not show up on the page. In other words, if Joan Bennett has no News Links, or Media Links or Letters, her Profile page would only show the widgets for My Blogs and My Notices.

Fix:
1) When contributor profile page first loads, it makes API calls to fetch entries per section. If no entries are returned, the section is hidden. See function defined on _contributor.html Ln 122

2) When user clicks on the arrow to expand a section, an API call is made to fetch entries for that section. If number of entries returned is less than the limit/pagination threshold (20), Load More button following the last appended entry is hidden. See Ln 105 in _contributor.html

3) If the Load more button is tapped/clicked but number of entries returned is less than the limit/pagination threshold (20), Load More button below the last appended entry for that section is hidden. See Ln. 157 in _contributor.html.
