### PR TITLE
Linking names under About->Guest Writers to search

### DIFF
--- a/craft/templates/about/guests.html
+++ b/craft/templates/about/guests.html
@@ -10,7 +10,7 @@
       <ul class="posts">
         {% for guest in craft.users.group('guest').limit(null).order('lastName, firstName') if craft.entries.authorId(guest.id).total > 0 %}
           <li class="listing">
-            <h3 class="contributor">{{ p.nameCase(guest.name) }}</h3>
+            <h3 class="contributor"><a href="/search?query={{ p.nameCase(guest.name) }}&type=exact">{{ p.nameCase(guest.name) }}</a></h3>
             <div class="profession">
               {% if guest.titleOrProfession %}
                 {{ guest.titleOrProfession }}<br>


### PR DESCRIPTION
Re: Task List Rev:  04-05-19 Item #1
1. GUEST WRITERS NAME SEARCH RESULT
Click on ABOUT then GUEST WRITERS. This is a list of users who have “guest” status and have created Posts. Because Guests are not offered a “Profile” page, it is just a static list.
Task: To launch a search when you click on a name, that produces an “exact phrase” search result. If that is too difficult, using our default “all of these” also seems to work okay.

Commit message:
Previously unlinked Guest Writer names under About->Guest Writers
are now linked to /search?query=<name>&type=exact so that clicking
them opens the search result page that shows matching results.
Note that we do an 'exact match' by specifying type=exact in the
path. 'section' parameter is omitted because we search across all
sections.