### PR TITLE
Bug Fix: Repeated Search Results Upon Scrolling

### DIFF
--- a/public/js/search.js
+++ b/public/js/search.js
@@ -31,7 +31,7 @@ $(function() {
         //----------
 
         var currentContentLength = function() {
-          return $('.listing').length;
+          return $('ul.posts.search li').length;
         };
 
         var loadMoreContent = function() {


### PR DESCRIPTION
Fixed Bug : Go to About->Guest Writers. Click on William Callahan. Reduce the height of the browser window until the scroll bar shows up. Scroll down all the way until you see the same search results being appended to existing search result.

Fix: If the search result included 'letters', the offset was incorrect because it was based on number of elements with class 'listings'. Letter results do not have that class. The fix is to base the count of search listings using the CSS selector "ul.posts.search li" instead of `.listings`.