### PR TITLE
Hitting Close on My Images/Documents should redirect to current page

### DIFF
--- a/craft/templates/_form/documents-sa.html
+++ b/craft/templates/_form/documents-sa.html
@@ -163,7 +163,7 @@ $(function() {
         modal.dialog('close');
       },#}
       Close: function() {
-        document.location.href="/";
+        window.history.back();
         modal.dialog('close');
       },
       Delete: function() {

--- a/craft/templates/_form/images-sa.html
+++ b/craft/templates/_form/images-sa.html
@@ -158,10 +158,10 @@ $(function() {
     dialogClass: 'no-close',
     buttons: {
       {#OK: function() {
-	document.location.href="/";	
+	      window.history.back();
       },#}
       Close: function() {
-	document.location.href="/";	
+	      window.history.back();
         modal.dialog('close');
       },
       Delete: function() {


### PR DESCRIPTION
Enhancement request:
From the HOME PAGE, click on MY ACCOUNT, MY IMAGES or MY DOCUMENTS.
When a user is finished adding images or documents and clicks on “CLOSE” they are redirected to the HOME PAGE. Change it so that they are still on / redirected to whatever page they were on when they opened the MY IMAGES or the MY DOCUMENTS widget.

Fix:
Instead of using document.location.href='/', use window.history.back() to navigate to the page from where user clicke My Images or My Documents.

Testing:
Tested on Chrome, Safari & Firefox on Desktop.

Other Info:
Task List MARIN POST 04-20-19
2. LANDING PAGE after MY IMAGES or MY DOCUMENTS
From the HOME PAGE, click on MY ACCOUNT, MY IMAGES or MY DOCUMENTS.
When a user is finished adding images or documents and clicks on “CLOSE” they are redirected to the HOME PAGE. Change it so that they are still on / redirected to whatever page they were on when they opened the MY IMAGES or the MY DOCUMENTS widget.