### PR TITLE
Subscription Content under Accordion on  'My Subscription' page

### DIFF
--- a/craft/templates/account/subscription/_content_fields.html
+++ b/craft/templates/account/subscription/_content_fields.html
@@ -13,62 +13,74 @@
 {% endfor %}
 
 <br>
-<br>
-<fieldset class="custom {{ m.grayedOutByDefault() }}"><legend>LOCATIONS</legend>
-  <input type="hidden" name="fields[subscriptionLocations]">
+<h4>Choose Content</h4>
+<main class="clearfix">
+  <div class="sub-nav">
+    {% block subNav %}
+      {% cache unless craft.config.cacheTagDisabled %}
+      <div class="filter" id="filters">
+        <fieldset class="custom {{ m.grayedOutByDefault() }}">
+          <input type="hidden" name="fields[subscriptionLocations]">
+          <h5>Locations</h5>
+          <ul>
+            {% set group = null %}
+            {% for location in craft.categories.group('locations') %}
+              {% if location.geographicGroup != group %}
+                {% set group = location.geographicGroup %}
+                <div class="location-group" style="margin-left: 0px; margin-top: 0px; padding-top: 12px; margin-bottom: 5px; padding-bottom: 0px;">{{ group.label }}</div>
+              {% endif %}
+              <li><input name="fields[subscriptionLocations][]" type="checkbox" value="{{ location.id }}" data-parent="{{ craft.mpfilter.parentLocationId(location) }}" data-children="{{ craft.mpfilter.childLocationIds(location) }}" {{ m.checked(location.id, locationIds) }} {{ m.disabledByDefault() }}/><label for="{{ location.id }}">{{ location.title }}</label></li>
+            {% endfor %}
+          </ul>
+        </fieldset>
 
-  {% set group = null %}
-  {% for location in craft.categories.group('locations') %}
-    {% if location.geographicGroup != group %}
-      {% set group = location.geographicGroup %}
-      <div class="location-group">{{ group.label }}</div>
-    {% endif %}
+        <fieldset class="custom {{ m.grayedOutByDefault() }}">
+          <input type="hidden" name="fields[subscriptionTopics]">
+          <h5>Topics</h5>
+          <ul>
+            <li><input type="checkbox" id="all-topics" {{ m.disabledByDefault }}/><label for="topics-all">All Topics</label></li>
 
-    <label>
-      <input type="checkbox" name="fields[subscriptionLocations][]" value="{{ location.id }}" data-parent="{{ craft.mpfilter.parentLocationId(location) }}" data-children="{{ craft.mpfilter.childLocationIds(location) }}" {{ m.checked(location.id, locationIds) }} {{ m.disabledByDefault() }} />
-      {{ location.title }}
-      &nbsp;
-    </label>
-  {% endfor %}
-</fieldset>
+            {% for topic in craft.categories.group('topics') %}
+            <li><input type="checkbox" name="fields[subscriptionTopics][]" value="{{ topic.id }}" id="{{ topic.id }}" {{ m.checked(topic.id, topicIds) }} {{ m.disabledByDefault() }} /><label for="{{ topic.id }}">{{ topic.title }}</label></li>
+            {% endfor %}
+          </ul>
+        </fieldset>
+        <fieldset class="custom {{ m.grayedOutByDefault() }}">
+          <input type="hidden" name="fields[subscriptionAuthors]">
+          <h5>Authors</h5>
+          <ul>
+            <li><input type="checkbox" class="author all" id="all-authors" {{ m.disabledByDefault }}/><label for="all-authors">All</label></li>
 
-<br>
-<fieldset class="custom {{ m.grayedOutByDefault() }}"><legend>TOPICS</legend>
-  <input type="hidden" name="fields[subscriptionTopics]">
+            {% for author in craft.users.group('contributor', 'guest').limit(null).order('lastName, firstName') if craft.entries.authorId(author.id).total > 0 %}
+            <li><input type="checkbox" name="fields[subscriptionAuthors][]" value="{{ author.id }}" id="{{ author.id }}" {{ m.checked(author.id, authorIds) }} {{ m.disabledByDefault() }} /><label for="{{ author.id }}">{{ p.nameCase(author.name) }}</label></li>
+            {% endfor %}
+          </ul>
+        </fieldset>
+        <fieldset class="custom {{ m.grayedOutByDefault() }}">
+          <input type="hidden" name="fields[subscriptionLetters]">
+          <h5 style="border-bottom: 1px solid #ccc;">Letters</h5>
+          <ul style="border-bottom: 1px solid #ccc; padding-top: 12px;">
+            <li><input type="checkbox" class="letter all" name="fields[subscriptionLetters][]" value="1" {{ currentUser.subscriptionLetters | length ? 'checked="checked"' : '' }} {{ m.disabledByDefault() }} id="letters-all"/><label for="letters-all">All</label></li>
+          </ul>
+        </fieldset>
+      </div>
+      {% endcache %}
+    {% endblock %}
+  </div>
 
-  <label><input type="checkbox" id="all-topics" {{ m.disabledByDefault }} />All Topics</label><br>
-
-  {% for topic in craft.categories.group('topics') %}
-    <label>
-      <input type="checkbox" name="fields[subscriptionTopics][]" value="{{ topic.id }}" {{ m.checked(topic.id, topicIds) }} {{ m.disabledByDefault() }} />
-      {{ topic.title }}
-      &nbsp;
-    </label>
-  {% endfor %}
-</fieldset>
-
-<br>
-<fieldset class="custom {{ m.grayedOutByDefault() }}"><legend>AUTHORS</legend>
-  <input type="hidden" name="fields[subscriptionAuthors]">
-
-  <label><input type="checkbox" id="all-authors" {{ m.disabledByDefault }} />All Authors</label><br>
-
-  {% for author in craft.users.group('contributor', 'guest').limit(null).order('lastName, firstName') if craft.entries.authorId(author.id).total > 0 %}
-    <label>
-      <input type="checkbox" name="fields[subscriptionAuthors][]" value="{{ author.id }}" {{ m.checked(author.id, authorIds) }} {{ m.disabledByDefault() }} />
-      {{ p.nameCase(author.name) }}
-      &nbsp;
-    </label>
-  {% endfor %}
-</fieldset>
-
-<br>
-<fieldset class="custom {{ m.grayedOutByDefault() }}"><legend>LETTERS</legend>
-  <input type="hidden" name="fields[subscriptionLetters]">
-
-  <label>
-    <input type="checkbox" name="fields[subscriptionLetters][]" value="1" {{ currentUser.subscriptionLetters | length ? 'checked="checked"' : '' }} {{ m.disabledByDefault() }} />
-    All Letters
-    &nbsp;
-  </label>
-</fieldset>
+  <div class="list-wrapper">
+    <ul class="posts">
+      {% block posts %}
+      {% endblock %}
+    </ul>
+  </div>
+</main>
+{% set js %}
+  $(function() {
+    $('ul.posts').filters({
+      locations: '{{ craft.request.query("locations") }}',
+      topics: '{{ craft.request.query("topics") }}'
+    });
+  });
+{% endset %}
+{% includeJs js %}

--- a/craft/templates/account/subscription/_content_fields.html
+++ b/craft/templates/account/subscription/_content_fields.html
@@ -13,7 +13,11 @@
 {% endfor %}
 
 <br>
+{% if not craft.mpSubscription.activeSubscription(currentUser) %}
 <h4>Choose Content</h4>
+{% else %}
+<h4>Edit Content Choices</h4>
+{% endif %}
 <main class="clearfix" style="padding-bottom: 0px;">
   <div class="sub-nav">
     {% block subNav %}

--- a/craft/templates/account/subscription/_content_fields.html
+++ b/craft/templates/account/subscription/_content_fields.html
@@ -18,7 +18,7 @@
 {% else %}
 <h4>Edit Content Choices</h4>
 {% endif %}
-<main class="clearfix" style="padding-bottom: 0px;">
+<main class="clearfix content-choices">
   <div class="sub-nav">
     {% block subNav %}
       {% cache unless craft.config.cacheTagDisabled %}
@@ -32,8 +32,12 @@
               {% if location.geographicGroup != group %}
                 {% set group = location.geographicGroup %}
                 <div class="location-group" style="margin-left: 0px; margin-top: 0px; padding-top: 12px; margin-bottom: 5px; padding-bottom: 0px;">{{ group.label }}</div>
-              {% endif %}
-              <li><input name="fields[subscriptionLocations][]" type="checkbox" value="{{ location.id }}" data-parent="{{ craft.mpfilter.parentLocationId(location) }}" data-children="{{ craft.mpfilter.childLocationIds(location) }}" {{ m.checked(location.id, locationIds) }} {{ m.disabledByDefault() }}/><label for="{{ location.id }}">{{ location.title }}</label></li>
+              {% endif %}              
+              <label>
+                  <input type="checkbox" name="fields[subscriptionLocations][]" value="{{ location.id }}" data-parent="{{ craft.mpfilter.parentLocationId(location) }}" data-children="{{ craft.mpfilter.childLocationIds(location) }}" {{ m.checked(location.id, locationIds) }} {{ m.disabledByDefault() }} />
+                  {{ location.title }}
+                  &nbsp;
+                </label>
             {% endfor %}
           </ul>
         </fieldset>
@@ -42,10 +46,14 @@
           <input type="hidden" name="fields[subscriptionTopics]">
           <h5>Topics</h5>
           <ul>
-            <li><input type="checkbox" id="all-topics" {{ m.disabledByDefault }}/><label for="topics-all">All Topics</label></li>
+            <label><input type="checkbox" id="all-topics" {{ m.disabledByDefault }} />All Topics</label><br/>
 
             {% for topic in craft.categories.group('topics') %}
-            <li><input type="checkbox" name="fields[subscriptionTopics][]" value="{{ topic.id }}" id="{{ topic.id }}" {{ m.checked(topic.id, topicIds) }} {{ m.disabledByDefault() }} /><label for="{{ topic.id }}">{{ topic.title }}</label></li>
+            <label>
+              <input type="checkbox" name="fields[subscriptionTopics][]" value="{{ topic.id }}" {{ m.checked(topic.id, topicIds) }} {{ m.disabledByDefault() }} />
+              {{ topic.title }}
+              &nbsp;
+            </label>
             {% endfor %}
           </ul>
         </fieldset>
@@ -53,18 +61,26 @@
           <input type="hidden" name="fields[subscriptionAuthors]">
           <h5>Authors</h5>
           <ul>
-            <li><input type="checkbox" class="author all" id="all-authors" {{ m.disabledByDefault }}/><label for="all-authors">All</label></li>
+              <label><input type="checkbox" id="all-authors" {{ m.disabledByDefault }} />All Authors</label><br>
 
-            {% for author in craft.users.group('contributor', 'guest').limit(null).order('lastName, firstName') if craft.entries.authorId(author.id).total > 0 %}
-            <li><input type="checkbox" name="fields[subscriptionAuthors][]" value="{{ author.id }}" id="{{ author.id }}" {{ m.checked(author.id, authorIds) }} {{ m.disabledByDefault() }} /><label for="{{ author.id }}">{{ p.nameCase(author.name) }}</label></li>
-            {% endfor %}
+              {% for author in craft.users.group('contributor', 'guest').limit(null).order('lastName, firstName') if craft.entries.authorId(author.id).total > 0 %}
+                <label>
+                  <input type="checkbox" name="fields[subscriptionAuthors][]" value="{{ author.id }}" {{ m.checked(author.id, authorIds) }} {{ m.disabledByDefault() }} />
+                  {{ p.nameCase(author.name) }}
+                  &nbsp;
+                </label>
+              {% endfor %}
           </ul>
         </fieldset>
         <fieldset class="custom {{ m.grayedOutByDefault() }}">
           <input type="hidden" name="fields[subscriptionLetters]">
           <h5 style="border-bottom: 1px solid #ccc;">Letters</h5>
           <ul style="border-bottom: 1px solid #ccc; padding-top: 12px;">
-            <li><input type="checkbox" class="letter all" name="fields[subscriptionLetters][]" value="1" {{ currentUser.subscriptionLetters | length ? 'checked="checked"' : '' }} {{ m.disabledByDefault() }} id="letters-all"/><label for="letters-all">All</label></li>
+            <label>
+              <input type="checkbox" name="fields[subscriptionLetters][]" value="1" {{ currentUser.subscriptionLetters | length ? 'checked="checked"' : '' }} {{ m.disabledByDefault() }} />
+              All Letters
+              &nbsp;
+            </label>
           </ul>
         </fieldset>
       </div>

--- a/craft/templates/account/subscription/_content_fields.html
+++ b/craft/templates/account/subscription/_content_fields.html
@@ -14,9 +14,9 @@
 
 <br>
 {% if not craft.mpSubscription.activeSubscription(currentUser) %}
-<h4>Choose Content</h4>
+<h4 class="custom-content-container-heading custom {{ m.grayedOutByDefault() }}">Choose Content</h4>
 {% else %}
-<h4>Edit Content Choices</h4>
+<h4 class="custom-content-container-heading custom {{ m.grayedOutByDefault() }}">Edit Content Choices</h4>
 {% endif %}
 <main class="clearfix content-choices">
   <div class="sub-nav">
@@ -25,7 +25,7 @@
       <div class="filter" id="filters">
         <fieldset class="custom {{ m.grayedOutByDefault() }}">
           <input type="hidden" name="fields[subscriptionLocations]">
-          <h5>Locations</h5>
+          <h5 class="custom {{ m.grayedOutByDefault() }}">Locations</h5>
           <ul>
             {% set group = null %}
             {% for location in craft.categories.group('locations') %}
@@ -44,7 +44,7 @@
 
         <fieldset class="custom {{ m.grayedOutByDefault() }}">
           <input type="hidden" name="fields[subscriptionTopics]">
-          <h5>Topics</h5>
+          <h5 class="custom {{ m.grayedOutByDefault() }}">Topics</h5>
           <ul>
             <label><input type="checkbox" id="all-topics" {{ m.disabledByDefault }} />All Topics</label><br/>
 
@@ -59,7 +59,7 @@
         </fieldset>
         <fieldset class="custom {{ m.grayedOutByDefault() }}">
           <input type="hidden" name="fields[subscriptionAuthors]">
-          <h5>Authors</h5>
+          <h5 class="custom {{ m.grayedOutByDefault() }}">Authors</h5>
           <ul>
               <label><input type="checkbox" id="all-authors" {{ m.disabledByDefault }} />All Authors</label><br>
 
@@ -74,7 +74,7 @@
         </fieldset>
         <fieldset class="custom {{ m.grayedOutByDefault() }}">
           <input type="hidden" name="fields[subscriptionLetters]">
-          <h5 style="border-bottom: 1px solid #ccc;">Letters</h5>
+          <h5 class="custom {{ m.grayedOutByDefault() }}" style="border-bottom: 1px solid #ccc;">Letters</h5>
           <ul style="border-bottom: 1px solid #ccc; padding-top: 12px;">
             <label>
               <input type="checkbox" name="fields[subscriptionLetters][]" value="1" {{ currentUser.subscriptionLetters | length ? 'checked="checked"' : '' }} {{ m.disabledByDefault() }} />

--- a/craft/templates/account/subscription/_content_fields.html
+++ b/craft/templates/account/subscription/_content_fields.html
@@ -14,7 +14,7 @@
 
 <br>
 <h4>Choose Content</h4>
-<main class="clearfix">
+<main class="clearfix" style="padding-bottom: 0px;">
   <div class="sub-nav">
     {% block subNav %}
       {% cache unless craft.config.cacheTagDisabled %}

--- a/craft/templates/account/subscription/_create_form.html
+++ b/craft/templates/account/subscription/_create_form.html
@@ -17,11 +17,11 @@
   {% include 'account/subscription/_stripe_fields.html' %}
 
   <hr>
-  <h3>Email Alerts</h3>
+  <h3>Email Alert Frequency</h3>
   {% include 'account/subscription/_frequency_fields.html' %}
 
   <hr>
-  <h3>Email Content</h3>
+  <h3>Weekly Email Alert Content</h3>
   {% include 'account/subscription/_content_fields.html' %}
 
   <br>

--- a/craft/templates/account/subscription/_free.html
+++ b/craft/templates/account/subscription/_free.html
@@ -1,4 +1,4 @@
-<h2>My Email Alerts</h2>
+<h2>My Subscription</h2>
 
 {# Note: immitate format of "site message" help class #}
 
@@ -11,7 +11,7 @@
 
 {# Opt in: subscribe #}
 
-<h2>Become a Marin Post Subscriber</h2>
+<h2><strong>Become a Marin Post Subscriber</strong></h2>
 
 <div class="help subscription">{{ n.siteMessage('account/subscribe') }}</div>
 

--- a/craft/templates/account/subscription/_paid.html
+++ b/craft/templates/account/subscription/_paid.html
@@ -44,7 +44,7 @@
 {% include 'account/subscription/_frequency_form.html' %}
 
 <hr>
-<h3>Email Alert Choices</h3>
+<h3>Weekly Email Alert Content</h3>
 {% include 'account/subscription/_content_form.html' %}
 
 {% if not currentUser.subscriptionCanceled %}

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -669,6 +669,33 @@ fieldset:last-of-type h5, .submit .sub-nav h5:last-of-type, .about .sub-nav h5:l
     display: none;
 }
 
+.subscription .filter > fieldset, .subscription .sub-nav .filter > h5, .subscription .sub-nav > h5, .subscription .sub-nav h2, .subscription .archive {
+    display: block;
+}
+
+.subscription .sub-nav {
+    width: 100%; 
+    padding-top: 0;
+}
+
+.subscription .sub-nav .filter > fieldset > h5 {
+    border-bottom: none;
+}
+
+.subscription .sub-nav .filter > fieldset > ul {
+    border: none; 
+    border-left: 1px solid #ccc;
+    border-right: 1px solid #ccc;
+    padding: 12px;
+    padding-left: 27px;
+    padding-top: 0px;
+}
+
+.subscription .sub-nav .filter > fieldset > ul > li {
+    border: none;
+    margin-bottom: 0px;
+}
+
 /* * * * * * * * * * * * * * * * * * * * *
         CONTENT
 * * * * * * * * * * * * * * * * * * * * * */
@@ -920,7 +947,7 @@ ul.tags > li {
 }
 .filter input[type="checkbox"] {
 	float: left;
-	margin: 1em .5em 0 0;
+	margin: 1em .5em 0 0 !important;
 }
 .filter .date-picker {
   display: none;
@@ -1182,14 +1209,6 @@ h2 span.preview button.close {
     color: blue;
 }
 
-.subscription fieldset {
-    border: 1px solid #c0c0c0;
-    margin: 0 2px;
-    padding: 0.35em 0.625em 0.75em;
-}
-.subscription legend {
-    font-weight: bold;
-}
 .subscription fieldset .location-group {
     text-decoration: underline;
     margin: 12px;
@@ -1942,7 +1961,7 @@ footer {
     }
 
 	.filter input[type="checkbox"] {
-		margin-top: .5em;
+		margin-top: .5em !important;
 	}
 
     #comments {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1218,7 +1218,7 @@ h2 span.preview button.close {
     text-decoration: underline;
     margin: 12px;
 }
-.subscription fieldset.disabled legend, .subscription fieldset.disabled .location-group, .subscription fieldset.disabled label {
+.subscription fieldset.disabled legend, .subscription fieldset.disabled .location-group, .subscription fieldset.disabled label, .subscription h5.disabled, .subscription .custom-content-container-heading.disabled {
     color: #c0c0c0;
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -932,6 +932,11 @@ ul.tags > li {
     display: none;
     font-size: .9em;
 }
+
+.subscription .filter ul {
+    font-size: 0.95em;
+}
+
 .filter ul > li {
     border: 1px solid #d2def4;
     border-top: none;
@@ -947,7 +952,7 @@ ul.tags > li {
 }
 .filter input[type="checkbox"] {
 	float: left;
-	margin: 1em .5em 0 0 !important;
+	margin: 1em .5em 0 0;
 }
 .filter .date-picker {
   display: none;
@@ -1528,6 +1533,13 @@ footer {
 		padding: 0;
         width: 37%;
     }
+
+    
+}
+
+.content-choices {
+    padding: 0;
+    width: 100%;
 }
 
 @media only screen and (min-width: 39em) { /* Tablet 39–50 ems */
@@ -1961,7 +1973,7 @@ footer {
     }
 
 	.filter input[type="checkbox"] {
-		margin-top: .5em !important;
+		margin-top: .2em !important;
 	}
 
     #comments {

--- a/public/js/subscription.js
+++ b/public/js/subscription.js
@@ -24,7 +24,7 @@
             var authorCheckboxes   = filterForm.find('input[name="fields[subscriptionAuthors][]"]');
             var allAuthorsCheckbox = filterForm.find('#all-authors');
             var letterCheckbox     = filterForm.find('input[name="fields[subscriptionLetters][]"]');
-            var customContent      = filterForm.find('fieldset.custom, fieldset.custom > .location-group');
+            var customContent      = filterForm.find('fieldset.custom, fieldset.custom > .location-group, fieldset.custom > h5.custom, h4.custom-content-container-heading.custom');
             var contentRadio       = filterForm.find('input[name="fields[subscriptionContent]"]');
 
             var expirationDate = cancelForm.find('.expiration-date');


### PR DESCRIPTION
Previously, subscription content checkboxes were inside <legend> element. It
is now part of the accordion and stylized in a one column layout. Other minor copy changes exist on that page.

Full  list of changes:
1. change title to 'My Subscription'
2. embolden 'Become a Marin Post Subscriber'
3. change 'Email Alerts' to 'Email Alert Frequency'
4. change 'Email Content' to 'Weekly Email Alert Content'
5. added title 'Choose Content'
6. changing the 'legend' type Locations/Topics/Authors/Letters to collapsible widget:  prototype/design/responsive/qa
7. seperate the CSS styles from inline code to main.css
8. change title from 'Email Alert Choices' to 'Weekly Email Alert Content'

These are change requests from task list v MARIN POST 04-20-19

3. SUBSCRIPTION FORM PAGE CHANGES
See Attached MOCK UP of new page. The mockup shows the 2 different states of the page. The first is for a user who has not “subscribed” (a paid subscription). The second is for a user who has a paid subscription.
The mockups show a variety of changes to titles and other minor arrangements.
The mockups also show one major change. That is that the selections of the various filters of types of information a user wishes to receive in their “Weekly Update” is no longer fully displayed on the page. It is now activated by the same widget that we use on the Profile page – in other words, clicking on the arrow opens and closes each of the selection types.
The default when a user comes to the page is closed. If a user leaves the page and comes back, it is again closed, even if they left the page with it open.

Note:
- Subscription sign-up was tested successfully using the TEST Stripe CC and verified that Content choices are indeed saved.
- Styling changes were made to ensure that the accordion is responsive.