### PR TITLE
Display count of search results on search page.

### DIFF
--- a/craft/templates/search.html
+++ b/craft/templates/search.html
@@ -75,6 +75,15 @@
           <input type="radio" name="section" value="notices" {{ checkSection('notices')}}> Notices
           <input type="radio" name="section" value="media" {{ checkSection('media')}}> Media
           <input type="radio" name="section" value="letters" {{ checkSection('letters')}}> Letters
+          {% if entryIds | length %}
+          <span style="float:right">{{ entryIds | length }} 
+            {% if (entryIds | length) == 1 %}
+            result
+            {% else %}
+            results
+            {% endif %} found
+          </span>
+          {% endif %}
         </fieldset>
       </form>
 

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -31,7 +31,7 @@ $(function() {
         //----------
 
         var currentContentLength = function() {
-          return $('ul.posts.search li').length;
+          return $('ul.posts.search > li').length;
         };
 
         var loadMoreContent = function() {


### PR DESCRIPTION
This is regarding Change Request #4  SEARCH RESULTS PAGE  in Task List MARIN POST 04-28-19
"Several users have asked if we can show the number of search results for a search. Assuming it is not too difficult to implement such a display result, I’ve shown a possible UI display of that. 
Please advise me about the ease or difficulty of implementing this before commencing. It will be important to test this UI change when it is viewed in the narrowest view for a mobile phone. "

If the number of search results is exactly one, a phrase displays
to the right of radio buttons aligned right "1 result found".

If the number of search results is more than one, a phrase displays
to the right of the radio buttons. "X results found".

It was tested on mobile and desktop.

Important: As part of this commit, a regression bug was identified
and fixed. The bug is that some search results that should match
the search do not appear. Read on to understand the fix for it.

The auto loading algorithm determines the offset by counting the
number of posts currently displayed on the search post. Currently,
it counts by using $('posts.search li') expression. This counts
li elements that are nested within parent li elements as well. The
fix was to change the expression to $('posts.search > li') to count
only top level li elements each that uniquely determines a search result.
See search.js changes.