### PR TITLE
Adding "Post blog/notice/letter/news/media" links to My blog/notice/letter/news/media pages

### DIFF
--- a/craft/templates/account/_layout.html
+++ b/craft/templates/account/_layout.html
@@ -21,8 +21,10 @@
 
   <div class="list-wrapper">
     {% block post %}
-      <h2 class="comment-count">{{ title }}</h2>
-
+      <div style="border-bottom: 1px solid #C8D4E9; margin: 1.25em 0 .75em; padding: 0.1em 0;">
+        <h2 style="display: inline-block; margin-bottom: unset; border-bottom: unset; margin-top: unset;">{{ title }}</h2>
+        <a style="float: right; line-height: 2.4;" href="{{ post_link }}">Post {{ post_title }}</a>
+      </div>
       <ul class="posts">
         {% for entry in entries %}
           {{ p.post(entry) }}

--- a/craft/templates/account/blog.html
+++ b/craft/templates/account/blog.html
@@ -1,3 +1,5 @@
 {% set section = 'blog' %}
 {% set title = 'My Blog Posts' %}
+{% set post_link = '/submit/blog' %}
+{% set post_title = 'a Blog' %}
 {% extends "account/entries/_section" %}

--- a/craft/templates/account/letters.html
+++ b/craft/templates/account/letters.html
@@ -1,3 +1,5 @@
 {% set section = 'letters' %}
 {% set title = 'My Letters' %}
+{% set post_link = '/submit/letter' %}
+{% set post_title = 'a Letter' %}
 {% extends "account/entries/_section" %}

--- a/craft/templates/account/media.html
+++ b/craft/templates/account/media.html
@@ -1,3 +1,5 @@
 {% set section = 'media' %}
 {% set title = 'My Media Links' %}
+{% set post_link = '/submit/media' %}
+{% set post_title = 'Media' %}
 {% extends "account/entries/_section" %}

--- a/craft/templates/account/news.html
+++ b/craft/templates/account/news.html
@@ -1,3 +1,5 @@
 {% set section = 'news' %}
 {% set title = 'My News Links' %}
 {% extends "account/entries/_section" %}
+{% set post_link = '/submit/news' %}
+{% set post_title = 'News' %}

--- a/craft/templates/account/notices.html
+++ b/craft/templates/account/notices.html
@@ -1,3 +1,5 @@
 {% set section = 'notices' %}
 {% set title = 'My Notices' %}
 {% extends "account/entries/_section" %}
+{% set post_link = '/submit/notice' %}
+{% set post_title = 'a Notice' %}


### PR DESCRIPTION
Adding "Post a Blog | a Notice | a Letter | News | Media" link under My Accounts -> My Blog/My Notices/My News/My Media/My Letters pages
respectively.

\<h2\> housing the title of these pages previously is now inlined with
a link (\<a\>) element as children of a containing div. CSS was adjusted
so that the title and link text are near baseline aligned and the rest
of spacings are preserved. During the synopsis, an undefined (dead) css class
'comment-count' was found and removed from \<h2\> inside account/_layout.html.

This commit pertains to Change Request # 5 in Task list "MARIN POST
04-20-19".

5\. Add “CREATE A …(POST)” links on each page under MY ACCOUNT / MY BLOGS, MY
NOTICES, etc.
Some users have asked if we can add a “Create a Blog” or a “Create a Notice” and so forth, link
to the pages under MY ACCOUNT for MY BLOGS, MY NOTICES, MY NEWS, MY MEDIA and MY
LETTERS…. As a quick way to get to the “create” form pages for each.
This would be located to the upper right hand side of the center div, as shown below. It is
aligned with the page title, “My Blog Posts” but registered to the right.
It will be important to test this UI change when it is viewed in the narrowest view for a mobile
phone.