### PR TITLE
support adding a document by double clicking.

### DIFF
--- a/craft/templates/_form/document.html
+++ b/craft/templates/_form/document.html
@@ -183,6 +183,12 @@ $(function() {
     updateDeleteButton();
   });
 
+  srcFiles.on('dblclick', 'li', function(e) {
+    selectFile($(this));
+    populateDocumentFromModal();
+    modal.dialog('close');
+  });
+
   fileInput.s3direct({
     bucket: "{{ s3.bucket }}",
     subfolder: "{{ s3.subfolder }}",

--- a/craft/templates/_form/documents.html
+++ b/craft/templates/_form/documents.html
@@ -244,6 +244,12 @@
        updateDeleteButton();
      });
 
+     srcFiles.on('dblclick', 'li', function(e) {
+       selectFile($(this));
+       populateDocumentFromModal();
+       modal.dialog('close');
+     });
+
      fileInput.s3direct({
        bucket: "{{ s3.bucket }}",
        subfolder: "{{ s3.subfolder }}",


### PR DESCRIPTION
previously document from the documents browser could be added
only by single click on the document image/title and hitting ok.
with this change, document can be added by simply double clicking.

Post blog page can be used to test this change. Click on Add a Document
on Post Blog page.