### PR TITLE
Bug Fix. Detach image from a post if user deletes it.

### DIFF
--- a/craft/templates/_form/image.html
+++ b/craft/templates/_form/image.html
@@ -145,6 +145,12 @@ $(function() {
           selectedImage.remove();
           updateDeleteButton();
           updateOkButton();
+
+          // If this image was attached to the entry, detach and replace with default image
+          if(targetFileId.val() == assetId){
+            targetFileId.val('').trigger('change');
+            targetImage.prop('src', defaultImagePath);
+          }
         }
       });
     }


### PR DESCRIPTION
Fixes the following bug:
- create a post
- add an image
- save
- edit the same post
- click replace the image
- delete the attached image
- hit cancel. Note the blog image is still the same as the deleted one.
- hit save. Fails. An error occurs.

Log shows the following error:
2019/06/11 06:34:02 [error] [system.db.CDbCommand] CDbCommand::execute() failed: SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`marinpost`.`craft_relations`, CONSTRAINT `craft_relations_targetId_fk` FOREIGN KEY (`targetId`) REFERENCES `craft_elements` (`id`) ON DELETE CASCADE). The SQL statement executed was: INSERT INTO `craft_relations` (`fieldId`, `sourceId`, `sourceLocale`, `targetId`, `sortOrder`, `dateCreated`, `dateUpdated`, `uid`) VALUES (:row0_col0, :row0_col1, NULL, :row0_col3, :row0_col4, :row0_col5, :row0_col6, :row0_col7).

The fix is two folds. If the attached image is deleted in the image browser,
a) the display image is substituted with the default image.
b) the hidden input field fields[blogImages] value is set to blank.

Relates to following change request in TaskList 05-22-19:
"
7. DELETE / REMOVE AN IMAGE FROM A NEW POST
If I am a new user and I am creating a post (Blog, Notice, News or Media posts), and if I’m using the Image Library to upload an image, I can accidently break the page.
A post form comes with a DEFAULT IMAGE already loaded. A user can create a post and publish it using that image, without uploading their own image to the Image Library.
However, if I have no images in the Library and upload one to use with a post, but then decide I don’t like that image so I “delete” it and then close the Image Library (because I don’t have time to finish the post now or whatever), the “DEFAULT” image that was originally there won’t be replaced and the page breaks.
TASK: Make it so in this instance, the DEFAULT IMAGE still appears in the post form.
[NOTE: This does not happen with documents because documents are not a “required” field]
[ALSO NOTE: If a user has already published a post and they go into their Image Library and delete the image they used for it, and then just click away from the page, somehow the default image does repopulate the image space on the published post – I have no idea how]
"