### PR TITLE
support selecting an image from image browser using double click

### DIFF
--- a/craft/templates/_form/documents.html
+++ b/craft/templates/_form/documents.html
@@ -121,20 +121,7 @@
                 alert("Only 5 documents can be attached at max.");
             } else {
                 // check if already exist
-                var alreadyExists = false;
-                for(var property in targetFileId){
-                    if (targetFileId.hasOwnProperty(property)) {
-                        if(typeof targetFileId[property].val === "function"){
-                            var targetFileIdValue = targetFileId[property].val();
-                            if(targetFileIdValue == docId){
-                                // already exists ignore
-                                alreadyExists = true;
-                                break;
-                            }
-                        }
-                    }
-                }
-                if(!alreadyExists){
+                if (!targetFileId.is(function(){return this.value == docId})) {
                     // create HTML
                     var docHTML = `<div class="field document" style="width:100%;">
                             <span class="document-title">${docTitle}</span>

--- a/craft/templates/_form/image.html
+++ b/craft/templates/_form/image.html
@@ -195,6 +195,12 @@ $(function() {
     updateDeleteButton();
   });
 
+  srcFiles.on('dblclick', 'li', function(e) {
+    selectImage($(this));
+    populateImageFromModal();
+    modal.dialog('close');
+  });
+
   fileInput.s3direct({
     bucket: "{{ s3.bucket }}",
     subfolder: "{{ s3.subfolder }}",


### PR DESCRIPTION
just like documents, images can now be selected using double click
in addition to the existing way, i.e. single click and hitting OK.

in addition, code was also refactored in documents.html to make
it shorter and less convoluted using jQuery provided helpers.