### PR TITLE
bold, underline & italics now work on redactor; adding horizontal line button for admin editor.

### DIFF
--- a/craft/config/redactor/Deluxe.json
+++ b/craft/config/redactor/Deluxe.json
@@ -1,5 +1,5 @@
 {
 	plugins: ['fullscreen','video','fontfamily','fontsize','fontcolor','underline','alignment'],
-	buttons: ['html','formatting','bold','italic','fontfamily','fontsize','fontcolor','unorderedlist','orderedlist','link','outdent','indent','alignment','image','video'],
+	buttons: ['html','formatting','bold','italic','fontfamily','fontsize','fontcolor','unorderedlist','orderedlist','link','outdent','indent','alignment','image','video', 'horizontalrule'],
 	toolbarFixed: true
 }

--- a/craft/plugins/README.md
+++ b/craft/plugins/README.md
@@ -21,3 +21,8 @@ Note the following Craft plugins have been modified:
 4. RedactorI
 
 	git show 4041fb8fa72a4c616eff8db61e758a59901ac887 public/js/redactor.js
+
+5. RedactorI
+
+  git show 2a297b0a4dfb343f67d1d46e4b3e0fa8bf22e7e2 public/js/redactor.js
+  git show 2a297b0a4dfb343f67d1d46e4b3e0fa8bf22e7e2 craft/plugins/redactori/resources/lib/redactor/redactor.js

--- a/craft/plugins/redactori/resources/lib/redactor/redactor.js
+++ b/craft/plugins/redactori/resources/lib/redactor/redactor.js
@@ -7636,6 +7636,13 @@
 					{
 						var node2 = this.selection.getMarker(2);
 						this.selection.setMarker(this.range, node2, false);
+
+						// concrete5 start - https://github.com/concrete5/concrete5/issues/5406
+						if (this.utils.browser('chrome'))
+						{
+							this.caret.set(node1, 0, node2, 0);
+						}
+						// concrete5 end						
 					}
 
 					this.savedSel = this.$editor.html();

--- a/public/js/redactor.js
+++ b/public/js/redactor.js
@@ -7635,6 +7635,13 @@
 					{
 						var node2 = this.selection.getMarker(2);
 						this.selection.setMarker(this.range, node2, false);
+
+						// concrete5 start - https://github.com/concrete5/concrete5/issues/5406
+						if (this.utils.browser('chrome'))
+						{
+							this.caret.set(node1, 0, node2, 0);
+						}
+						// concrete5 end						
 					}
 
 					this.savedSel = this.$editor.html();


### PR DESCRIPTION
This PR has two parts:

1) Fixing Bold, Underline & Italics on admin+public redactor editor.
This is a known redactor bug fixed in Redactor 3.0. However, we are stuck with Redactor 2.0 because of Craft CMS 2.0 compatibility issues.
    
Therefore, the fix is to manually port the recommended fix into the plugin code.
    
See the following StackOverflow article describing the issue and fix:
https://stackoverflow.com/questions/43674400/redactor-editor-text-format-issues-with-chrome-version-58
    
See the GitHub issue page for the known issue:
https://github.com/concrete5/concrete5/issues/5406

2) Adding support for horizontal line in the admin redactor editor for entries.

These changes pertain to 8. in the Task list: "MARIN POST 05-22-19". The original idea was to  implement CK Editor but after a phone call with Bob, we decided to fix the existing bug on Chrome with Redactor. This PR addresses those bugs.

[1 - TASKS LIST - MARIN POST 06-09-19.pdf](https://github.com/communityventurepartners/marinpost/files/3292405/1.-.TASKS.LIST.-.MARIN.POST.06-09-19.pdf)
