### PR TITLE
Support embedding an image in blog/notice content.

### DIFF
--- a/craft/templates/_common/layout.html
+++ b/craft/templates/_common/layout.html
@@ -191,6 +191,7 @@
         '/var/www/marinpost.org/public/js/redactor/fullscreen.js',
         '/var/www/marinpost.org/public/js/redactor/limiter.js',
         '/var/www/marinpost.org/public/js/redactor/underline.js',
+        '/var/www/marinpost.org/public/js/redactor/addimage.js',
         '/var/www/marinpost.org/public/js/console.js',
         '/var/www/marinpost.org/public/js/home.js',
         '/var/www/marinpost.org/public/js/search.js',
@@ -227,6 +228,7 @@
     <script src="{{ siteUrl }}js/redactor/fullscreen.js"></script>
     <script src="{{ siteUrl }}js/redactor/limiter.js"></script>
     <script src="{{ siteUrl }}js/redactor/underline.js"></script>
+    <script src="{{ siteUrl }}js/redactor/addimage.js"></script>
     <script src="{{ siteUrl }}js/console.js"></script>
     <script src="{{ siteUrl }}js/home.js"></script>
     <script src="{{ siteUrl }}js/search.js"></script>

--- a/craft/templates/_form/image-redactor.html
+++ b/craft/templates/_form/image-redactor.html
@@ -1,0 +1,195 @@
+{% set sourceId = 3 %}
+{% set folder = craft.s3direct.s3Folder(sourceId) %}
+{% set s3 = craft.s3direct.s3UploadForm(sourceId) %}
+{% set assets = false %}
+{% if folder %}
+  {% set assets = craft.assets.folderId(folder.id).limit(null).find %}
+{% endif %}
+
+{% set transform = userProfile ? 'profile' : 'list' %}
+{% set excerptLength = 20 %}
+<input type="hidden" id="selected-img-url" value=""/>
+<div id="image-modal-2" class="upload-modal image" title="My Images" style="display: none;">
+    <div>
+        <div class="help">{{ n.siteMessage('my/images') }}</div>
+    </div>
+
+    <div>
+    <div class="upload-wrapper clearfix">
+        <span class="fileinput-button">
+        <span>Upload an image</span>
+        <input id="image-fileupload" type="file" name="file" accept="image/gif,image/jpg,image/jpeg,image/png">
+        <img class="s3direct image" src="/img/spinner.gif" style="display: none;"/>
+        </span>
+
+        <div class="s3direct image progress-bar progress-bar-success"></div>
+    </div>
+
+    <div class="files-wrapper clearfix">
+        <ul id="src-files" {% if not assets %}style="display: none;"{% endif %}>
+        {% if folder %}
+            {% for asset in assets %}
+            <li data-asset-id="{{ asset.id }}" data-asset-url="{{ asset.url(transform) }}" title="{{ asset.title }}">
+                <div><img src="{{ asset.url(transform) }}" /></div>
+                <span class="title">{{ p.excerpt(asset.title, excerptLength) }}</span>
+            </li>
+            {% endfor %}
+        {% endif %}
+        </ul>
+    </div>
+    </div>
+</div>
+
+{% set js %}
+$(function() {
+    var modal2 = $('#image-modal-2');
+    var fileInput2 = modal2.find('#image-fileupload');
+    var srcFiles2 = modal2.find('ul#src-files');
+    
+    var modal = $('#image-modal');
+    var srcFiles = modal.find('ul#src-files');
+    var okButton2 = false;
+    var deleteButton2 = false;
+    var deleteAssetUrl = '{{ actionUrl("mpEntry/deleteAsset") }}';
+    
+    var selectedImage2 = function() {
+        return srcFiles2.children('li.selected:first');
+    }
+
+    var selectImage2 = function(li) {
+        li.parent().children().removeClass('selected');
+        li.addClass('selected');
+    };
+
+    var updateOkButton2 = function() {
+        okButton2.button((selectedImage2().length == 1) ? 'enable' : 'disable');
+    };
+
+    var populateListFromIndex2 = function(files) {
+        var selectedId = selectedImage2().attr('data-asset-id');
+        srcFiles2.children().remove();
+    
+        $.each(files, function(index, file) {
+          var selected = file.id == selectedId ? 'class="selected"' : '';
+          var title = file.title.length > {{ excerptLength }} ? file.title.slice(0, {{ excerptLength }})+'...' : file.title;
+    
+          srcFiles2.append('<li data-asset-id="'+file.id+'" data-asset-url="'+file.url+'"' +selected+'><div><img src="'+file.url+'" /></div><span class="title">'+title+'</span></li>');
+        });
+    
+        srcFiles2.show();
+
+        // Also update the other list
+        selectedId = selectedImage2().attr('data-asset-id');
+        srcFiles.children().remove();
+    
+        $.each(files, function(index, file) {
+          var selected = file.id == selectedId ? 'class="selected"' : '';
+          var title = file.title.length > {{ excerptLength }} ? file.title.slice(0, {{ excerptLength }})+'...' : file.title;
+    
+          srcFiles.append('<li data-asset-id="'+file.id+'" data-asset-url="'+file.url+'"' +selected+'><div><img src="'+file.url+'" /></div><span class="title">'+title+'</span></li>');
+        });
+    
+        srcFiles.show();
+    };
+
+    var populateImageFromModal2 = function() {
+        var selectedImage2 = srcFiles2.children('li.selected:first');
+
+        if (selectedImage2.length == 1) {
+            console.log(selectedImage2.attr('data-asset-url'));
+            $('#selected-img-url').val(selectedImage2.attr('data-asset-url'));           
+        } else {
+            $('#selected-img-url').val('');
+        }
+    };
+
+    var updateDeleteButton2 = function() {
+        deleteButton2.button((selectedImage2().length == 1) ? 'enable' : 'disable');
+    };
+
+    var deleteImage2 = function() {
+        var selectedImage2 = srcFiles2.children('li.selected:first');
+        var assetId2;
+
+        if (selectedImage2.length == 1) {
+            assetId2 = selectedImage2.attr('data-asset-id');
+
+            $.post(deleteAssetUrl, { assetId: assetId2 }, function(data) {
+                if (data.error) {
+                    alert(data.error);
+                } else {
+                    selectedImage2.remove();
+
+                    // delete this li from any other HTML as well
+                    var selectedId = selectedImage2.attr('data-asset-id');
+                    $('[data-asset-id="'+selectedId+'"]').remove();
+
+                    updateDeleteButton2();
+                    updateOkButton2();
+                }
+            });
+        }
+    };
+
+    modal2.dialog({
+        modal2: true,
+        autoOpen: false,
+        height: window.matchMedia("(min-width: 51em)").matches ? $(window).height() * 0.75 : $(window).height(),
+        width: window.matchMedia("(min-width: 51em)").matches ? $(window).width() * 0.75 : $(window).width(),
+        dialogClass: 'no-close',
+        buttons: {
+            OK: function() {
+                populateImageFromModal2();
+                modal2.dialog('close');
+            },
+            Cancel: function() {
+                $('#selected-img-url').val('');
+                modal2.dialog('close');
+            },
+            Delete: function() {
+                deleteImage2();
+            }
+        },
+        open: function(event, ui) {
+            // deselect any existing image
+            $('#image-modal-2 div .files-wrapper ul#src-files li').removeClass("selected");
+            var widget2 = $(this).dialog('widget');
+            okButton2 = widget2.find('.ui-dialog-buttonpane button:contains(OK)');
+            updateOkButton2();
+            deleteButton2 = widget2.find('.ui-dialog-buttonpane button:contains(Delete)');
+            updateDeleteButton2();
+        },
+        closeOnEscape: false,
+    });
+
+    srcFiles2.on('click', 'li', function(e) {
+        selectImage2($(this));
+        updateOkButton2();
+        updateDeleteButton2();
+    });
+
+    srcFiles2.on('dblclick', 'li', function(e) {
+        selectImage2($(this));
+        populateImageFromModal2();
+        modal2.dialog('close');
+    });
+
+    fileInput2.s3direct({
+        bucket: "{{ s3.bucket }}",
+        subfolder: "{{ s3.subfolder }}",
+        currentUserId: "{{ currentUser.id }}",
+        policy: "{{ s3.policy }}",
+        signature: "{{ s3.signature }}",
+        accessKey: "{{ s3.keyId }}",
+        assetsSourceId: {{ sourceId }},
+        acceptFileTypes: /.+\.(gif|jpe?g|png)$/i,
+        imageTransform: '{{ transform }}',
+        uploadProgressBarSelector: '#image-modal-2 div .upload-wrapper .s3direct.image.progress-bar',
+        updateIndexIndicatorSelector: '#image-modal-2 div .upload-wrapper .fileinput-button .s3direct.image',
+        onUpdateAssetsIndex: populateListFromIndex2,
+        requireFileCredit: true,
+        debug: true,
+    });
+});
+{% endset %}
+{% includeJs js %}

--- a/craft/templates/_form/image.html
+++ b/craft/templates/_form/image.html
@@ -88,6 +88,9 @@ $(function() {
   var deleteButton = false;
   var deleteAssetUrl = '{{ actionUrl("mpEntry/deleteAsset") }}';
   
+  var modal2 = $('#image-modal-2');
+  var srcFiles2 = modal2.find('ul#src-files');
+
   var selectedImage = function() {
     return srcFiles.children('li.selected:first');
   }
@@ -109,6 +112,18 @@ $(function() {
     });
 
     srcFiles.show();
+
+    selectedId = selectedImage().attr('data-asset-id');
+    srcFiles2.children().remove();
+
+    $.each(files, function(index, file) {
+      var selected = file.id == selectedId ? 'class="selected"' : '';
+      var title = file.title.length > {{ excerptLength }} ? file.title.slice(0, {{ excerptLength }})+'...' : file.title;
+
+      srcFiles2.append('<li data-asset-id="'+file.id+'" data-asset-url="'+file.url+'"' +selected+'><div><img src="'+file.url+'" /></div><span class="title">'+title+'</span></li>');
+    });
+
+    srcFiles2.show();
   };
 
   var updateOkButton = function() {
@@ -143,6 +158,10 @@ $(function() {
           alert(data.error);
         } else {
           selectedImage.remove();
+          // delete this li from any other HTML as well
+          var selectedId = selectedImage.attr('data-asset-id');
+          $('[data-asset-id="'+selectedId+'"]').remove();
+
           updateDeleteButton();
           updateOkButton();
 
@@ -211,8 +230,8 @@ $(function() {
     assetsSourceId: {{ sourceId }},
     acceptFileTypes: /.+\.(gif|jpe?g|png)$/i,
     imageTransform: '{{ transform }}',
-    uploadProgressBarSelector: '.s3direct.image.progress-bar',
-    updateIndexIndicatorSelector: 'img.s3direct.image',
+    uploadProgressBarSelector: '#image-modal div .upload-wrapper .s3direct.image.progress-bar',
+    updateIndexIndicatorSelector: '#image-modal div .upload-wrapper .fileinput-button .s3direct.image',
     onUpdateAssetsIndex: populateListFromIndex,
     requireFileCredit: true,
     debug: true,

--- a/craft/templates/submit/blog.html
+++ b/craft/templates/submit/blog.html
@@ -14,6 +14,7 @@
         {% include "_form/locations" %}
         {% include "_form/topics" %}
         {% include "_form/tags" %}
+        {% include "_form/image-redactor" %}        
         {% include "_form/content/blog" %}
         {% include "_form/documents" with { documentsAttribute: 'blogDocuments' } %}
         <div class="field">

--- a/craft/templates/submit/notice.html
+++ b/craft/templates/submit/notice.html
@@ -15,6 +15,7 @@
             {% include "_form/locations" %}
             {% include "_form/topics" %}
             {% include "_form/tags" %}
+            {% include "_form/image-redactor" %}
             {% include "_form/content/notice" %}
             {% include "_form/documents" with { documentsAttribute: 'noticeDocuments' } %}
         </fieldset>

--- a/public/js/contentform.js
+++ b/public/js/contentform.js
@@ -192,7 +192,7 @@
                   break;
                 case 'fields[blogContent]':
                 case 'fields[noticeContent]':
-                  plugins = plugins.concat(['fontsize', 'fontcolor', 'fontfamily']);
+                  plugins = plugins.concat(['addimage','fontsize', 'fontcolor', 'fontfamily']);
                   buttons = ['html'].concat(buttons);
                   buttons = buttons.concat(['fontsize', 'fontcolor', 'fontfamily', 'unorderedlist', 'orderedlist', 'outdent', 'indent', 'alignment', 'horizontalrule']);
                   break;

--- a/public/js/redactor.js
+++ b/public/js/redactor.js
@@ -141,7 +141,7 @@
 
 		imageEditable: true,
 		imageLink: true,
-		imagePosition: true,
+		imagePosition: false,
 		imageFloatMargin: '10px',
 		imageResizable: true,
 
@@ -301,7 +301,7 @@
 				columns: 'Columns',
 				add_head: 'Add Head',
 				delete_head: 'Delete Head',
-				title: 'Title',
+				title: 'Description of Image',
 				image_position: 'Position',
 				none: 'None',
 				left: 'Left',
@@ -6439,9 +6439,10 @@
 						+ '<section id="redactor-modal-image-edit">'
 							+ '<label>' + this.lang.get('title') + '</label>'
 							+ '<input type="text" id="redactor-image-title" />'
+							+ '<span style="font-size: 12px; font-style: italic;">Your title will help search engines find your content on the web. This title will not show on the published page.</span>'
 							+ '<label class="redactor-image-link-option">' + this.lang.get('link') + '</label>'
 							+ '<input type="text" id="redactor-image-link" class="redactor-image-link-option" aria-label="' + this.lang.get('link') + '" />'
-							+ '<label class="redactor-image-link-option"><input type="checkbox" id="redactor-image-link-blank" aria-label="' + this.lang.get('link_new_tab') + '"> ' + this.lang.get('link_new_tab') + '</label>'
+							+ '<label class="redactor-image-link-option"><input type="checkbox" id="redactor-image-link-blank" aria-label="' + this.lang.get('link_new_tab') + '" checked=true> ' + this.lang.get('link_new_tab') + '</label>'
 							+ '<label class="redactor-image-position-option">' + this.lang.get('image_position') + '</label>'
 							+ '<select class="redactor-image-position-option" id="redactor-image-align" aria-label="' + this.lang.get('image_position') + '">'
 								+ '<option value="none">' + this.lang.get('none') + '</option>'

--- a/public/js/redactor/addimage.js
+++ b/public/js/redactor/addimage.js
@@ -1,0 +1,26 @@
+/**
+ * Redactor plugin for supporting 'add image' button via existing s3 image picker
+ */
+
+if (!RedactorPlugins) var RedactorPlugins = {};
+
+RedactorPlugins.addimage = function () {
+    return {
+        init: function () {
+            var modal = $('#image-modal-2');
+            const thisObj = this;
+            modal.on('dialogclose', function (event) {
+                var url = $('#selected-img-url').val();
+                thisObj.insert.html("<img src='" + url + "'>");
+                thisObj.code.sync();
+            });
+
+            var button = this.button.addAfter('underline', 'image', 'Add Image');
+            this.button.addCallback(button, this.addimage.show);
+        },
+        show: function () {
+            var modal = $('#image-modal-2');
+            modal.dialog('open');
+        }
+    };
+};


### PR DESCRIPTION
Users can now embed an image in blog/notice content. An 'Add Image'
button shows up to the right of the underline button in the redactor
editor on the create/edit blog/notice pages. User taps 'Add Image',
image picker shows up that behaves exactly the way the existing image
picker shows up. It displays the user's media library and gives him/her
an option to upload, delete, select an image or cancel the dialog.
Upon choosing an image and hitting OK, the selected image is embedded
into the editor. User can further edit the image by clicking on the
embedded image and hitting the 'Edit' button atop it. For example: the
image can be given a title, can be made into a link and the link can
be opened in a new tab, can be aligned (left/center/right), can be
deleted, etc.

A custom Redactor plugin - 'addimage' - adds the 'Add Image' button to
UI, shows image picker when this button is tapped, and embeds the selected
image upon hitting ok. The file public/js/redactor/addimage.js
encapsulates all logic of this plugin.

The blog and notice twig templates now includes a new twig template
called as 'image-redactor'. This twig template encapsulates the
second image picker. This image picker is separate to the one used
by 'Image' field of the form and intentionally kept separate so as
to not interfere with the existing picker's functionality. See
craft/templates/_form/image-redactor.html for more details.

Due to the existence of two pickers, there is logic in place to sync
the images in both pickers if they are added or deleted in either of
the two pickers.

This change request pertains to #9 in the 06-16-19 task list below:

"
9. ADD NEW TEXT EDITOR “INSERT IMAGE” FEATURE FOR USERS
Our current ADMIN View offers the ability to “Insert Image” into the content of a BLOG or NOTICE. I would like offer this feature from our users, so they can upload and place images on their blog / notice pages in between text content. The image and text will always be separated (no wrapped text).
However, I want the “insert image” to bring up their personal user Image Library popup. So they can load it into their Library and then insert it with a double click.
This raises issues about linking the feature to AWS, as we discussed.
TASK: Add the capability for users to add images to their post content.
NOTE: This capability already exists in the Redactor text editor in the ADMIN view except it loads the image into the main Admin library on Digital Ocean.
"