### PR TITLE
Adding 'Help' navigation menu item.

### DIFF
--- a/craft/templates/_common/layout.html
+++ b/craft/templates/_common/layout.html
@@ -136,6 +136,7 @@
         <li class="bottom-only sign-up"><a href="{{ url('account/register') }}">Sign up</a></li>
       {% endif %}
       <li>{{ n.segmentLink('Donate') }}</li>
+      <li>{{ n.segmentLink('Help', 'frequently-asked-questions') }}</li>
       <li class="bottom-only"><a href="#" class="show-search">Search</a></li>
     </ul>
   </nav>

--- a/craft/templates/_common/layout.html
+++ b/craft/templates/_common/layout.html
@@ -136,7 +136,10 @@
         <li class="bottom-only sign-up"><a href="{{ url('account/register') }}">Sign up</a></li>
       {% endif %}
       <li>{{ n.segmentLink('Donate') }}</li>
-      <li>{{ n.segmentLink('Help', 'frequently-asked-questions') }}</li>
+      {% set helpEntry = craft.entries.section('Help').first() %}
+      {% if helpEntry.status == 'live' %}
+        <li>{{ n.segmentLink('Help', 'frequently-asked-questions') }}</li>
+      {% endif %}
       <li class="bottom-only"><a href="#" class="show-search">Search</a></li>
     </ul>
   </nav>

--- a/craft/templates/help.html
+++ b/craft/templates/help.html
@@ -1,0 +1,16 @@
+{% extends "_common/layout" %}
+
+{% set title = entry.title %}
+
+{% block main %}
+  {% embed "_common/single" %}
+    {% block title %}{{ entry.title }}{% endblock %}
+
+    {% block subNav %}
+    {% endblock %}
+
+    {% block post %}
+      <div class="help">{{ entry.genericContent }}</div>
+    {% endblock %}
+  {% endembed %}
+{% endblock %}


### PR DESCRIPTION
The 'Help' navigation menu item links to /frequently-asked-questions
page. The page is a 'Single' entry tied to the newly created section
'Help'. The section has already been created in DEV Admin. See:
Settings->Sections->Help. The corresponding single entry is in
Entries->Singles->Help. Title and Content fields are required in the
entry and the content field is pre-populated with the content of the
About entry for demo purpose only. One issue that I encountered when
working on this feature was that nav links appeared 'blue' and
'underlined' when using '/help' as the URI for this section. This is
because craft assigns the class to the body element based on the
path. So, it was assigning class 'help' to body. And we had CSS rules
for an already used class 'help' thats assigned to the content wrapper
that interfered with the navigation links. Therefore, I resorted to
changing the URI to /frequently-asked-questions instead. Another issue
that was encountered after doing so was that HELP menu item would not
show as active (emboldened) when on that page.

Tested OK on Desktop and Mobile. Please review and promote to DEV if
all looks good.

NOTE (IMPORTANT): If Bob QA's it OK on DEV, please let me know before promoting this to production so I can make those changes on PROD. They are pretty self
confined. So, the risk of regressions should be zero.

This is pertaining to #10 in Tasklist MARIN POST 06-22-19 revision 1:
10. ADD “HELP” PAGE TO SITE AND TO “SINGLES” IN CRAFT ADMIN
Management of the site and customer support would benefit from having a “HELP” page on the site that provided answers to “Frequently Asked Questions” about how to use the Marin Post.
TASK: To set up a new main menu choice for “HELP” which will be located to the right of “DONATE” at the top of the page.
This new page will be administered in the “Admin Dashboard” under “Entries” “Singles”. The “Singles” page currently has pages for About, Donate, Home, Privacy Policy, and Terms of Use.
The new “Help” page will essentially be a copy of the “About” or “Donate” pages, giving me the same functionality and features and ability to add text, images, etc. With that set up, I will create the content of the page.
The main page title at the top of the page will be “Frequently Asked Questions.”