### PR TITLE
eliminate "open link in new tab" checkbox field and make it default behaviour

### DIFF
--- a/craft/plugins/README.md
+++ b/craft/plugins/README.md
@@ -33,4 +33,4 @@ Note the following Craft plugins have been modified:
 
 7. RedactorI
 
-  git show f13c2c1a0a75b50325d8cceea23a4ac67702c230 public/js/redactor.js
+  git show a8fbf97ce40cde3a8d51cfd6ba4346c7e4f39f1d public/js/redactor.js

--- a/craft/plugins/README.md
+++ b/craft/plugins/README.md
@@ -34,3 +34,4 @@ Note the following Craft plugins have been modified:
 7. RedactorI
 
   git show a8fbf97ce40cde3a8d51cfd6ba4346c7e4f39f1d public/js/redactor.js
+  git show ff449411d761374d7dda246d354125e349ccc085 public/js/redactor.js

--- a/craft/plugins/README.md
+++ b/craft/plugins/README.md
@@ -30,3 +30,7 @@ Note the following Craft plugins have been modified:
 6. RedactorI
    
   git show 82f83622f0d8f2f8dc230f794aaf5cfd4690ff75 public/js/redactor.js
+
+7. RedactorI
+
+  git show f13c2c1a0a75b50325d8cceea23a4ac67702c230 public/js/redactor.js

--- a/public/js/redactor.js
+++ b/public/js/redactor.js
@@ -6472,7 +6472,7 @@
 							+ '<input type="url" id="redactor-link-url" aria-label="URL" />'
 							+ '<label>' + this.lang.get('text') + '</label>'
 							+ '<input type="text" id="redactor-link-url-text" aria-label="' + this.lang.get('text') + '" />'
-							+ '<label><input type="checkbox" id="redactor-link-blank"> ' + this.lang.get('link_new_tab') + '</label>'
+							+ '<label><input type="checkbox" checked id="redactor-link-blank"> ' + this.lang.get('link_new_tab') + '</label>'
 						+ '</section>'
 					};
 

--- a/public/js/redactor.js
+++ b/public/js/redactor.js
@@ -3659,8 +3659,7 @@
 						$redactorImageLink.attr('href', $image.attr('src'));
 						if ($link.length !== 0)
 						{
-							$redactorImageLink.val($link.attr('href'));
-							if ($link.attr('target') == '_blank') $('#redactor-image-link-blank').prop('checked', true);
+							$redactorImageLink.val($link.attr('href'));							
 						}
 					}
 
@@ -3729,7 +3728,7 @@
 							link = this.opts.linkProtocol + '://' + link;
 						}
 
-						var target = ($('#redactor-image-link-blank').prop('checked')) ? true : false;
+						var target = true;
 
 						if ($link.length === 0)
 						{
@@ -6436,8 +6435,7 @@
 							+ '<input type="text" id="redactor-image-title" />'
 							+ '<span style="font-size: 12px; font-style: italic;">Your title will help search engines find your content on the web. This title will not show on the published page.</span>'
 							+ '<label class="redactor-image-link-option">' + this.lang.get('link') + '</label>'
-							+ '<input type="text" id="redactor-image-link" class="redactor-image-link-option" aria-label="' + this.lang.get('link') + '" />'
-							+ '<label class="redactor-image-link-option"><input type="checkbox" id="redactor-image-link-blank" aria-label="' + this.lang.get('link_new_tab') + '" checked=true> ' + this.lang.get('link_new_tab') + '</label>'
+							+ '<input type="text" id="redactor-image-link" class="redactor-image-link-option" aria-label="' + this.lang.get('link') + '" />'							
 							+ '<label class="redactor-image-position-option">' + this.lang.get('image_position') + '</label>'
 							+ '<select class="redactor-image-position-option" id="redactor-image-align" aria-label="' + this.lang.get('image_position') + '">'
 								+ '<option value="none">' + this.lang.get('none') + '</option>'

--- a/public/js/redactor.js
+++ b/public/js/redactor.js
@@ -5834,8 +5834,6 @@
 					this.link.getData();
 					this.link.cleanUrl();
 
-					if (this.link.target == '_blank') $('#redactor-link-blank').prop('checked', true);
-
 					this.link.$inputUrl = $('#redactor-link-url');
 					this.link.$inputText = $('#redactor-link-url-text');
 
@@ -5919,10 +5917,7 @@
 					// url, not anchor
 					else if (link.search('#') !== 0)
 					{
-						if ($('#redactor-link-blank').prop('checked'))
-						{
-							target = '_blank';
-						}
+						target = '_blank';
 
 						// test url (add protocol)
 						var pattern = '((xn--)?[a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}';
@@ -6472,7 +6467,6 @@
 							+ '<input type="url" id="redactor-link-url" aria-label="URL" />'
 							+ '<label>' + this.lang.get('text') + '</label>'
 							+ '<input type="text" id="redactor-link-url-text" aria-label="' + this.lang.get('text') + '" />'
-							+ '<label><input type="checkbox" checked id="redactor-link-blank"> ' + this.lang.get('link_new_tab') + '</label>'
 						+ '</section>'
 					};
 


### PR DESCRIPTION
The Redactor editor allows embedding link in images and text. Currently, a checkbox field "Open link in new tab" is exposed to users to choose if the link would open in same or new tab. By default, its unchecked meaning that links would open in same tab. These commits eliminate the field and always opens the links in new tab.

Related to Task List: MARIN POST 06-27-19  change request #11. 

11. CHANGE DEFAULT “New Window” FOR LINKS IN “LINK” WIDGET IN TEXT EDITOR
As it is, if you create a post as a User, you will see that the user has a “create a link” icon at the top of the text editor box, whereby they can highlight text and then insert a link.
You will also notice that when that opens, there is a small check box on the lower left of the “insert a link” popup box that provides the option to have the link open in a new tab.
However, the default is to have it open in the same tab, which takes the reader away from our site. This is something I never want to happen.
I want the default setting to be to open the link in a new tab. This must just be a setting because in the CRAFT ADMIN view of any blog/notice post, when you create a link through that view, the default is already set to “new window,” so I am assuming there is some setting in CRAFT to allow that for users when they create links.
This is also true for the “Image edit” function widget, which you just set at the checked default, to allow a user to add a URL link to an image that they have inserted into the Blog or Notice content box.
TASK: Change the default to be “open in a new tab”. This may mean changing the check box to read “Open in same tab” or being eliminated altogether. We can discuss.