### PR TITLE
implementing ability to preview documents in document browser

### DIFF
--- a/craft/templates/_form/documents-sa.html
+++ b/craft/templates/_form/documents-sa.html
@@ -189,8 +189,7 @@ $(function() {
   srcFiles.on('dblclick', 'li', function(e) {
     selectFile($(this));
     updateDeleteButton();
-    var selectedFile = srcFiles.children('li.selected:first');
-    var url = selectedFile.attr('data-asset-url');
+    var url = this.dataset.assetUrl;
     if(url)
       window.open(url, '_blank');
   });

--- a/craft/templates/_form/documents-sa.html
+++ b/craft/templates/_form/documents-sa.html
@@ -56,7 +56,7 @@ i#}
       <ul id="src-files" {% if not assets %}style="display: none;"{% endif %}>
         {% if folder %}
           {% for asset in assets %}
-            <li data-asset-id="{{ asset.id }}" data-asset-title="{{ asset.title }}" title="{{ asset.title }}" {% if asset.id == document.id %}class="selected"{% endif %}>
+            <li data-asset-id="{{ asset.id }}" data-asset-url="{{ asset.url }}" data-asset-title="{{ asset.title }}" title="{{ asset.title }}" {% if asset.id == document.id %}class="selected"{% endif %}>
               <div><img src="/img/default/list/pdf.jpg" /></div>
               <span class="title">{{ p.excerpt(asset.title, excerptLength) }}</span>
             </li>
@@ -140,7 +140,7 @@ $(function() {
       var selected = file.id == selectedId ? 'class="selected"' : '';
       var title = file.title.length > {{ excerptLength }} ? file.title.slice(0, {{ excerptLength }})+'...' : file.title;
 
-      srcFiles.append('<li data-asset-id="'+file.id+'" data-asset-title="'+file.title+'"' +selected+'><div><img src="/img/default/list/pdf.jpg" /></div><span class="title">'+title+'</span></li>');
+      srcFiles.append('<li data-asset-id="'+file.id+'" data-asset-url="'+file.url+'" data-asset-title="'+file.title+'"' +selected+'><div><img src="/img/default/list/pdf.jpg" /></div><span class="title">'+title+'</span></li>');
     });
 
     srcFiles.show();
@@ -184,6 +184,15 @@ $(function() {
     selectFile($(this));
     {#updateOkButton();#}
     updateDeleteButton();
+  });
+
+  srcFiles.on('dblclick', 'li', function(e) {
+    selectFile($(this));
+    updateDeleteButton();
+    var selectedFile = srcFiles.children('li.selected:first');
+    var url = selectedFile.attr('data-asset-url');
+    if(url)
+      window.open(url, '_blank');
   });
 
   fileInput.s3direct({


### PR DESCRIPTION
Under My Accounts->My Documents, Document Browser shows PDFs.
Currently, user can only delete a PDF but can't preview it.
With this change, user can double click a PDF and preview it
in a new tab.

An attribute data-asset-url was added to the list-item representing
a PDF document (asset in craft lingo). The value of this attribute
is populated to be the URL (using .url). A double click listener
is implemented that first marks the PDF as selected and then gets
the data-asset-url value from it and uses the window.open(<url>,
_blank) method to open the URL in a new tab.

Tested on Chrome with scenarios:
1) Double Click an existing PDF
2) Upload a new document and double click an existing PDF
3) Upload a new document and double click the uploaded PDF.

It pertains to MARIN POST 06-27-19 #12:
"
12. CLICK TO OPEN URL VIEW OF DOCUMENT IN DOCUMENT LIBRARY
It would be helpful when a user wants to insert a link (to text or an image) to a document that exists in the Document Library, to have a way to see the AWS URL for that document opening it in a new tab - the view that one sees as a reader when they click on a document PDF image on a published Blog or Notice page.
Would it be possible to allow users to access their Document Library under their MY ACCOUNT submenu and to then click on a document and have it open in a browser tab / window? This feature would only be available when they access it from MY ACCOUNT and not available when they are “adding a document” or otherwise accessing their Document Library from the Blog or Notice form.
Task: To allow a user to double-click on a PDF symbol of a document in their Document Library, to open that document in a brower window/tab
"
