### PR TITLE
Open pasted links in redactor editor in new tab

### DIFF
--- a/craft/plugins/README.md
+++ b/craft/plugins/README.md
@@ -36,6 +36,6 @@ Note the following Craft plugins have been modified:
   git show a8fbf97ce40cde3a8d51cfd6ba4346c7e4f39f1d public/js/redactor.js
   git show ff449411d761374d7dda246d354125e349ccc085 public/js/redactor.js
 
-7. RedactorI
+8. RedactorI
 
   git show 3d49e7f69c4cffdc12b3d7826f51cff66275e3db public/js/redactor.js

--- a/craft/plugins/README.md
+++ b/craft/plugins/README.md
@@ -35,3 +35,7 @@ Note the following Craft plugins have been modified:
 
   git show a8fbf97ce40cde3a8d51cfd6ba4346c7e4f39f1d public/js/redactor.js
   git show ff449411d761374d7dda246d354125e349ccc085 public/js/redactor.js
+
+7. RedactorI
+
+  git show 3d49e7f69c4cffdc12b3d7826f51cff66275e3db public/js/redactor.js

--- a/public/js/redactor.js
+++ b/public/js/redactor.js
@@ -7255,6 +7255,17 @@
 						});
 
 					}, this), 10);
+
+					// add target=_blank to pasted links
+					setTimeout($.proxy(function()
+					{
+						var links = this.$editor.find('a');
+						$.each(links, function(i,a)
+						{
+							$(a).attr('target','_blank');
+						});
+
+					}, this), 10);
 				}
 			};
 		},


### PR DESCRIPTION
Bob discovered a bug where if one pastes text containing links
in redactor editor, those links would open in same tab. The
desired behaviour is to open every link in new tab.

The fix is to add target=_blank to every link (a) element in
the generated HTML of the text pasted in the 'paste' #insert
callback.