### PR TITLE
Removing Add Image button from public redactor editor.

### DIFF
--- a/public/js/contentform.js
+++ b/public/js/contentform.js
@@ -192,7 +192,7 @@
                   break;
                 case 'fields[blogContent]':
                 case 'fields[noticeContent]':
-                  plugins = plugins.concat(['addimage','fontsize', 'fontcolor', 'fontfamily']);
+                  plugins = plugins.concat(['fontsize', 'fontcolor', 'fontfamily']);
                   buttons = ['html'].concat(buttons);
                   buttons = buttons.concat(['fontsize', 'fontcolor', 'fontfamily', 'unorderedlist', 'orderedlist', 'outdent', 'indent', 'alignment', 'horizontalrule']);
                   break;


### PR DESCRIPTION
Turning off embedding images in public redactor editor because embedded images are truncated and resized and are not good resolution. Per request from Bob.