### PR TITLE
Implementing embedding high res images in posts.

### DIFF
--- a/craft/plugins/s3direct/controllers/S3DirectController.php
+++ b/craft/plugins/s3direct/controllers/S3DirectController.php
@@ -35,7 +35,7 @@ class S3DirectController extends BaseController
             foreach ($assets as $asset)
             {
                 $url = $asset->kind == 'image' ? craft()->s3Direct->getAssetUrl($asset->id, $transform) : $asset->url;
-
+                $originalUrl = $asset->url;
                 array_push($outputFiles, array(
                     'id' => $asset->id,
                     'title' => $asset->title,
@@ -43,6 +43,7 @@ class S3DirectController extends BaseController
                     'kind' => $asset->kind,
                     'size' => $asset->size,
                     'url' => $url,
+                    'originalUrl' => $originalUrl
                 ));
             }
 

--- a/craft/plugins/s3direct/resources/css/s3direct.css
+++ b/craft/plugins/s3direct/resources/css/s3direct.css
@@ -15,6 +15,7 @@
 .upload-modal.image ul#src-files li {
   float: left;
   margin: 0 14px 14px 0;
+  padding: 5px;
   width: 45%;
 }
 

--- a/craft/templates/_common/layout.html
+++ b/craft/templates/_common/layout.html
@@ -124,7 +124,8 @@
             <li>{{ n.pathLInk('My News', 'account/news') }}</li>
             <li>{{ n.pathLInk('My Media', 'account/media') }}</li>
             <li>{{ n.pathLInk('My Letters', 'account/letters') }}</li>
-            <li>{{ n.pathLInk('My Images', 'account/images') }}</li>
+            <li>{{ n.pathLInk('My Content Images', 'account/contentimages') }}</li>
+            <li>{{ n.pathLInk('My Post Images', 'account/images') }}</li>
             <li>{{ n.pathLInk('My Documents', 'account/documents') }}</li> 
             <li>{{ n.pathLInk('My Subscription', 'account/subscription') }}</li>
             <li>{{ n.pathLInk('Delete Account', 'account/delete') }}</li>

--- a/craft/templates/_form/contentimages-sa.html
+++ b/craft/templates/_form/contentimages-sa.html
@@ -1,0 +1,205 @@
+{# NOTE: empty fields[fieldName][] MUST be removed (via Javascript) prior to form submission.
+    # See public/js/contentform.js and public/js/userform.js
+    #}
+   
+   {% set sourceId = 4 %}
+   {% set folder = craft.s3direct.s3Folder(sourceId) %}
+   {% set s3 = craft.s3direct.s3UploadForm(sourceId) %}
+   
+   {% set assets = false %}
+   {% if folder %}
+     {% set assets = craft.assets.folderId(folder.id).limit(null).find %}
+   {% endif %}
+   
+   {% set entry = userProfile ? currentUser : entry %}
+   {% set image = false %}
+   {% set errors = false %}
+   
+   {% if entry %}
+     {% set image = attribute(entry, imagesAttribute).first %}
+     {% set errors = image.hasErrors %}
+   {% endif %}
+   
+   {% set transform = 'emImgThumb' %}
+   {% set excerptLength = 20 %}
+   
+   {% set defaultImage = userProfile ? 'user.gif' : singularSection~'.jpg' %}
+   {% set defaultImagePath = '/img/default/'~transform~'/'~defaultImage %}
+   
+   {% if errors %}
+     {{ f.errorList(imageBlock.allErrors) }}
+   {% endif %}
+   
+   <input type="hidden" name="fields[{{ imagesAttribute }}]">
+   
+   <div class="image-field inputs">
+     <input type="hidden" name="fields[{{ imagesAttribute }}][]" {% if image %}value="{{ image.id }}"{% endif -%}>
+   </div>
+   
+   <div id="image-modal" class="upload-modal image" title="My Post Images" style="display: none;">
+     <div>
+       <div class="help">{{ n.siteMessage('my/images-sa') }}</div>
+     </div>
+   
+     <div>
+       <div class="upload-wrapper clearfix">
+         <span class="fileinput-button">
+           <span>Upload an image</span>
+           <input id="image-fileupload" type="file" name="file" accept="image/gif,image/jpg,image/jpeg,image/png">
+           <img class="s3direct image" src="/img/spinner.gif" style="display: none;"/>
+         </span>
+   
+         <div class="s3direct image progress-bar progress-bar-success"></div>
+       </div>
+   
+       <div class="files-wrapper clearfix">
+         <ul id="src-files" {% if not assets %}style="display: none;"{% endif %}>
+           {% if folder %}
+             {% for asset in assets %}
+               <li data-asset-id="{{ asset.id }}" data-asset-url="{{ asset.url() }}" title="{{ asset.title }}" {% if asset.id == image.id %}class="selected"{% endif %}>
+                 <div><img src="{{ asset.url(transform) }}" /></div>
+               </li>
+             {% endfor %}
+           {% endif %}
+         </ul>
+       </div>
+     </div>
+   </div>
+   
+   {% set js %}
+   $(function() {
+   
+     $(".submit").hide();
+   
+     var openModal = $('#open-image-modal');
+     var modal = $('#image-modal');
+     var fileInput = modal.find('#image-fileupload');
+     var srcFiles = modal.find('ul#src-files');
+   {#  var okButton = false;#}
+     var targetFileId = $('input[type=hidden][name="fields[{{ imagesAttribute }}][]"]');
+     var targetImage = $('img.display-image');
+     var defaultImagePath = '{{ defaultImagePath }}';
+     var deleteButton = false;
+     var deleteAssetUrl = '{{ actionUrl("mpEntry/deleteAsset") }}';
+     
+     var selectedImage = function() {
+       return srcFiles.children('li.selected:first');
+     }
+   
+     var selectImage = function(li) {
+       li.parent().children().removeClass('selected');
+       li.addClass('selected');
+     };
+     
+     var populateListFromIndex = function(files) {
+       var selectedId = selectedImage().attr('data-asset-id');
+       srcFiles.children().remove();
+   
+       $.each(files, function(index, file) {
+         var selected = file.id == selectedId ? 'class="selected"' : '';
+         var title = file.title.length > {{ excerptLength }} ? file.title.slice(0, {{ excerptLength }})+'...' : file.title;
+   
+         srcFiles.append('<li data-asset-id="'+file.id+'" data-asset-url="'+file.url+'"' +selected+'><div><img src="'+file.url+'" /></div></li>');
+       });
+   
+       srcFiles.show();
+     };
+   
+    {# var updateOkButton = function() {
+       okButton.button((selectedImage().length == 1) ? 'enable' : 'disable');
+     };
+   #}
+     var populateImageFromModal = function() {
+       var selectedImage = srcFiles.children('li.selected:first');
+   
+   
+       if (selectedImage.length == 1) {
+         targetFileId.val(selectedImage.attr('data-asset-id')).trigger('change');
+         targetImage.prop('src', selectedImage.attr('data-asset-url'));
+       } else {
+         targetFileId.val('').trigger('change');
+         targetImage.prop('src', defaultImagePath);
+       }
+     };
+     var updateDeleteButton = function() {
+       deleteButton.button((selectedImage().length == 1) ? 'enable' : 'disable');
+     };
+   
+     var deleteImage = function() {
+       var selectedImage = srcFiles.children('li.selected:first');
+       var assetId;
+   
+       if (selectedImage.length == 1) {
+         assetId = selectedImage.attr('data-asset-id');
+   
+         $.post(deleteAssetUrl, { assetId: assetId }, function(data) {
+           if (data.error) {
+             alert(data.error);
+           } else {
+             selectedImage.remove();
+             updateDeleteButton();
+             {#updateOkButton();#}
+           }
+         });
+       }
+     };
+   
+     openModal.click(function(e) {
+       e.preventDefault();
+       modal.dialog('open');
+     });
+   
+     modal.dialog({
+       modal: true,
+       autoOpen: true,
+       height: window.matchMedia("(min-width: 51em)").matches ? $(window).height() * 0.75 : $(window).height(),
+       width: window.matchMedia("(min-width: 51em)").matches ? $(window).width() * 0.75 : $(window).width(),
+       dialogClass: 'no-close',
+       buttons: {
+         {#OK: function() {
+             window.history.back();
+         },#}
+         Close: function() {
+             window.history.back();
+           modal.dialog('close');
+         },
+         Delete: function() {
+           deleteImage();
+         }
+       },
+       open: function(event, ui) {
+         var widget = $(this).dialog('widget');
+         {#okButton = widget.find('.ui-dialog-buttonpane button:contains(OK)');
+         updateOkButton();#}
+         deleteButton = widget.find('.ui-dialog-buttonpane button:contains(Delete)');
+         updateDeleteButton();
+       },
+       closeOnEscape: false,
+     });
+   
+     srcFiles.on('click', 'li', function(e) {
+       selectImage($(this));
+       {#updateOkButton();#}
+       updateDeleteButton();
+     });
+   
+     fileInput.s3direct({
+       bucket: "{{ s3.bucket }}",
+       subfolder: "{{ s3.subfolder }}",
+       currentUserId: "{{ currentUser.id }}",
+       policy: "{{ s3.policy }}",
+       signature: "{{ s3.signature }}",
+       accessKey: "{{ s3.keyId }}",
+       assetsSourceId: {{ sourceId }},
+       acceptFileTypes: /.+\.(gif|jpe?g|png)$/i,
+       imageTransform: '{{ transform }}',
+       uploadProgressBarSelector: '.s3direct.image.progress-bar',
+       updateIndexIndicatorSelector: 'img.s3direct.image',
+       onUpdateAssetsIndex: populateListFromIndex,
+       requireFileCredit: true,
+       debug: true,
+     });
+   });
+   {% endset %}
+   {% includeJs js %}
+   

--- a/craft/templates/_form/image-redactor.html
+++ b/craft/templates/_form/image-redactor.html
@@ -9,7 +9,7 @@
 {% set transform = 'emImgThumb' %}
 {% set excerptLength = 20 %}
 <input type="hidden" id="selected-img-url" value=""/>
-<div id="image-modal-2" class="upload-modal image" title="My Images" style="display: none;">
+<div id="image-modal-2" class="upload-modal image" title="My Content Images" style="display: none;">
     <div>
         <div class="help">{{ n.siteMessage('my/embedded/images') }}</div>
     </div>

--- a/craft/templates/_form/image-redactor.html
+++ b/craft/templates/_form/image-redactor.html
@@ -1,4 +1,4 @@
-{% set sourceId = 3 %}
+{% set sourceId = 4 %}
 {% set folder = craft.s3direct.s3Folder(sourceId) %}
 {% set s3 = craft.s3direct.s3UploadForm(sourceId) %}
 {% set assets = false %}
@@ -6,12 +6,12 @@
   {% set assets = craft.assets.folderId(folder.id).limit(null).find %}
 {% endif %}
 
-{% set transform = userProfile ? 'profile' : 'list' %}
+{% set transform = 'emImgThumb' %}
 {% set excerptLength = 20 %}
 <input type="hidden" id="selected-img-url" value=""/>
 <div id="image-modal-2" class="upload-modal image" title="My Images" style="display: none;">
     <div>
-        <div class="help">{{ n.siteMessage('my/images') }}</div>
+        <div class="help">{{ n.siteMessage('my/embedded/images') }}</div>
     </div>
 
     <div>
@@ -29,9 +29,8 @@
         <ul id="src-files" {% if not assets %}style="display: none;"{% endif %}>
         {% if folder %}
             {% for asset in assets %}
-            <li data-asset-id="{{ asset.id }}" data-asset-url="{{ asset.url(transform) }}" title="{{ asset.title }}">
+            <li data-asset-id="{{ asset.id }}" data-asset-url="{{ asset.url() }}" title="{{ asset.title }}">
                 <div><img src="{{ asset.url(transform) }}" /></div>
-                <span class="title">{{ p.excerpt(asset.title, excerptLength) }}</span>
             </li>
             {% endfor %}
         {% endif %}
@@ -47,7 +46,6 @@ $(function() {
     var srcFiles2 = modal2.find('ul#src-files');
     
     var modal = $('#image-modal');
-    var srcFiles = modal.find('ul#src-files');
     var okButton2 = false;
     var deleteButton2 = false;
     var deleteAssetUrl = '{{ actionUrl("mpEntry/deleteAsset") }}';
@@ -68,28 +66,15 @@ $(function() {
     var populateListFromIndex2 = function(files) {
         var selectedId = selectedImage2().attr('data-asset-id');
         srcFiles2.children().remove();
-    
+        console.log(files);
         $.each(files, function(index, file) {
           var selected = file.id == selectedId ? 'class="selected"' : '';
           var title = file.title.length > {{ excerptLength }} ? file.title.slice(0, {{ excerptLength }})+'...' : file.title;
     
-          srcFiles2.append('<li data-asset-id="'+file.id+'" data-asset-url="'+file.url+'"' +selected+'><div><img src="'+file.url+'" /></div><span class="title">'+title+'</span></li>');
+          srcFiles2.append('<li data-asset-id="'+file.id+'" data-asset-url="'+file.originalUrl+'"' +selected+'><div><img src="'+file.url+'" /></div></li>');
         });
     
         srcFiles2.show();
-
-        // Also update the other list
-        selectedId = selectedImage2().attr('data-asset-id');
-        srcFiles.children().remove();
-    
-        $.each(files, function(index, file) {
-          var selected = file.id == selectedId ? 'class="selected"' : '';
-          var title = file.title.length > {{ excerptLength }} ? file.title.slice(0, {{ excerptLength }})+'...' : file.title;
-    
-          srcFiles.append('<li data-asset-id="'+file.id+'" data-asset-url="'+file.url+'"' +selected+'><div><img src="'+file.url+'" /></div><span class="title">'+title+'</span></li>');
-        });
-    
-        srcFiles.show();
     };
 
     var populateImageFromModal2 = function() {

--- a/craft/templates/_form/image.html
+++ b/craft/templates/_form/image.html
@@ -44,7 +44,7 @@
   {{ n.siteMessage('add/replace/image') }}
 {% endif %}
 
-<div id="image-modal" class="upload-modal image" title="My Images" style="display: none;">
+<div id="image-modal" class="upload-modal image" title="My Post Images" style="display: none;">
   <div>
     <div class="help">{{ n.siteMessage('my/images') }}</div>
   </div>

--- a/craft/templates/_form/image.html
+++ b/craft/templates/_form/image.html
@@ -38,7 +38,7 @@
   <input type="hidden" name="fields[{{ imagesAttribute }}][]" {% if image %}value="{{ image.id }}"{% endif -%}>
 </div>
 
-<a href="#" id="open-image-modal">{{ image ? 'Replace Image' : 'Add an Image' }}</a>
+<a href="#" id="open-image-modal">{{ image ? 'Replace Post Image' : 'Add Post Image' }}</a>
 
 {% if not userProfile %}
   {{ n.siteMessage('add/replace/image') }}
@@ -89,7 +89,6 @@ $(function() {
   var deleteAssetUrl = '{{ actionUrl("mpEntry/deleteAsset") }}';
   
   var modal2 = $('#image-modal-2');
-  var srcFiles2 = modal2.find('ul#src-files');
 
   var selectedImage = function() {
     return srcFiles.children('li.selected:first');
@@ -112,18 +111,6 @@ $(function() {
     });
 
     srcFiles.show();
-
-    selectedId = selectedImage().attr('data-asset-id');
-    srcFiles2.children().remove();
-
-    $.each(files, function(index, file) {
-      var selected = file.id == selectedId ? 'class="selected"' : '';
-      var title = file.title.length > {{ excerptLength }} ? file.title.slice(0, {{ excerptLength }})+'...' : file.title;
-
-      srcFiles2.append('<li data-asset-id="'+file.id+'" data-asset-url="'+file.url+'"' +selected+'><div><img src="'+file.url+'" /></div><span class="title">'+title+'</span></li>');
-    });
-
-    srcFiles2.show();
   };
 
   var updateOkButton = function() {

--- a/craft/templates/_form/images-sa.html
+++ b/craft/templates/_form/images-sa.html
@@ -36,7 +36,7 @@
   <input type="hidden" name="fields[{{ imagesAttribute }}][]" {% if image %}value="{{ image.id }}"{% endif -%}>
 </div>
 
-<div id="image-modal" class="upload-modal image" title="My Images" style="display: none;">
+<div id="image-modal" class="upload-modal image" title="My Post Images" style="display: none;">
   <div>
     <div class="help">{{ n.siteMessage('my/images-sa') }}</div>
   </div>

--- a/craft/templates/account/_layout.html
+++ b/craft/templates/account/_layout.html
@@ -12,7 +12,8 @@
         {{ n.arrowLink('account/news', 'My News') }}
         {{ n.arrowLink('account/media', 'My Media') }}
         {{ n.arrowLink('account/letters', 'My Letters') }}
-        {{ n.arrowLink('account/images', 'My Images') }}
+        {{ n.arrowLink('account/images', 'My Post Images') }}
+        {{ n.arrowLink('account/contentimages', 'My Content Images') }}
         {{ n.arrowLink('account/documents', 'My Documents') }}
         {{ n.arrowLink('account/subscription', 'My Subscription', true) }}
         {{ n.arrowLink('account/delete', 'Delete Account') }}

--- a/craft/templates/account/contentimages.html
+++ b/craft/templates/account/contentimages.html
@@ -1,0 +1,15 @@
+{% requireLogin %}
+
+{% set sectionId = 4 %}
+
+{% extends "_common/layout" %}
+
+{% block main %}
+  {% embed "_form/layout" %}
+    {% block formFields %}
+        <div class="field clearfix">
+          {% include "_form/contentimages-sa"  %}
+        </div>
+    {% endblock %}
+  {% endembed %}
+{% endblock %}

--- a/public/js/contentform.js
+++ b/public/js/contentform.js
@@ -192,7 +192,7 @@
                   break;
                 case 'fields[blogContent]':
                 case 'fields[noticeContent]':
-                  plugins = plugins.concat(['fontsize', 'fontcolor', 'fontfamily']);
+                  plugins = plugins.concat(['addimage','fontsize', 'fontcolor', 'fontfamily']);
                   buttons = ['html'].concat(buttons);
                   buttons = buttons.concat(['fontsize', 'fontcolor', 'fontfamily', 'unorderedlist', 'orderedlist', 'outdent', 'indent', 'alignment', 'horizontalrule']);
                   break;

--- a/public/js/redactor/addimage.js
+++ b/public/js/redactor/addimage.js
@@ -15,7 +15,7 @@ RedactorPlugins.addimage = function () {
                 thisObj.code.sync();
             });
 
-            var button = this.button.addAfter('underline', 'image', 'Add Image');
+            var button = this.button.addAfter('underline', 'image', 'Insert Image');
             this.button.addCallback(button, this.addimage.show);
         },
         show: function () {


### PR DESCRIPTION
These changes enable users to upload an image and embed it in their
posts via the redactor editor *without* breaking the aspect ratio
or the resolution of the image. User now click on the 'Insert Image'
button in the post editor to invoke the image picker. The image picker
allows them to upload an image. Upon uploading the image, a thumbnail
depicting the image appears in the image picker. Note - we got rid of
the image titles per Bob's request. The text above the gallery is a
global message "my/embedded/images". Upon selecting an uploaded image
and hitting OK OR double clicking an image, embeds the originally
uploaded image into the editor that is scaled to fit, i.e, it will
resize (to lesser size) if its original width exceeded the available
editor width OR it will retain its original dimensions if the width
of the editor is more than its original width. Like before, users
can edit the embedded image, as in, clicking it and hitting Edit
button. A link or alt-text may be added.

Language was also changed a bit.
Add an Image -> Add Post Image
Replace Image -> Replace Post Image
Add Image (in editor) -> Insert Image

A new "Asset Source" of kind images was created in Admin called
"Embedded Images" (sourceId = 4). An Image Transform "Embedded
Image Thumb" was created for creating a "scaled to fit" thumbnail
with width 190px to show the uploaded image in the image picker.
A global message "my/embedded/images" was defined to show in the
image picker for this use case. The images are uploaded in the
emimg subfolder of the bucket. These have been done in DEV ADMIN
after testing on LOCAL. But NOT in PROD yet pending Review.

One change made in the S3 Direct plugin is to return the
originalUrl in addition to the transformed URL in the response
of the updateAssetsIndex API endpoint. The originalUrl is defined
for the embedded image whereas the url (transformed) is used to
display the uploaded image in picker.
See: craft/plugins/s3direct/controllers/S3DirectController.php

CSS changes were done to create a 5px padding around the image
thumbnails so that selection (gray background) is visible now
that we don't have the titles below the images for this image
picker.

Now that we have the embedded images in their own folder, the logic
to delete images in "embedded" image picker when deleted in "post"
image picker and viceversa has been yanked.
See: git diff craft/templates/_form/image-redactor.html
& git diff craft/templates/_form/image.html

Ofcourse the 'Insert Image' button in the public redactor editor
was re-instated.