### PR TITLE
Removing the margin aroud the image picker thumbnails 

### DIFF
--- a/craft/plugins/s3direct/resources/css/s3direct.css
+++ b/craft/plugins/s3direct/resources/css/s3direct.css
@@ -14,7 +14,6 @@
 
 .upload-modal.image ul#src-files li {
   float: left;
-  margin: 0 14px 14px 0;
   padding: 5px;
   width: 45%;
 }


### PR DESCRIPTION
Fixing the regression from previous checkin. A white margin appears on the right of the image picker. See image below:
![My Post Images copy](https://user-images.githubusercontent.com/43843468/61009931-464dc800-a329-11e9-9f5d-2d35ee3fcbe3.jpg)

The fix is to remove the 14px margins on the individual image list items now that padding of 5px surrounds them anyways.
