### PR TITLE
Hide social icons and social message on single column layout view.

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1310,7 +1310,7 @@ a.subscribe {
 	display: inline-block;
 	margin: 0 auto .75em auto;
 	text-align: center;
-  width: 70%;
+    width: 70%;
 }
 
 #share ul {
@@ -2012,4 +2012,18 @@ p {
 
 .remove-doc-link{
     cursor: pointer;
+}
+
+.hide-on-mobile {
+    display: block;
+}
+
+/* hide social media share icons on one column layout devices */
+@media only screen and (max-width: 815px) {
+    #share {
+        display: none;
+    }
+    .hide-on-mobile {
+        display: none;
+    }
 }


### PR DESCRIPTION
On wider browsers, such as Desktop, iPad Pro, the view has a
sidebar. On this sidebar, a row of social icons shows up followed
by Messages (Global Message of path 'home/right'). On narrower
browsers (with single column layout, <= 815px), we hide the social
icons. The VISIT US ON FACEBOOK message is also now hidden.

A cleaner fix would have been to use craft's helper isMobileBrowser
like so:

if(isMobileBrowser(true))
  //do not include the markup for social icons and message
else
  //include the markup for social icons and message

But it treats iPad Pro as Mobile but iPad Pro shows two column
layout. We want to  NOT hide the social icons on iPad Pro.

Therefore, I have resorted to using CSS media queries. The break
point of two col -> single col is 815px.

A hide-on-mobile class was created and attached to the <p> HTMl
element representing VISIT US ON FACEBOOK link/text in Global Message
"home/right" to conditionally hide only that message. This is done
on DEV ONLY. Once you promote to PROD, let me know and I will do
the same on PROD.

A minor indentation was fixed in main.css.